### PR TITLE
Added publish statements to dump_config

### DIFF
--- a/tests/test_det_config.py
+++ b/tests/test_det_config.py
@@ -21,7 +21,7 @@ def test_dev_cfg(cfg):
 
     # Testing reloading written config file
     cfg = DetConfig(sys_file=sys, dev_file=dev)
-    args = cfg.parse_args(args=['-N', '2'])
+    cfg.parse_args(args=['-N', '2'])
     assert (cfg.dev.bands[1]['dc_att'] == 3)
 
 
@@ -33,6 +33,12 @@ def test_failed_update(cfg):
 
 def test_offline_pysmurf_instance(cfg):
     cfg.parse_args(args=[])
-    S = cfg.get_smurf_control(offline=True, dump_configs=True)
+    cfg.get_smurf_control(offline=True, dump_configs=True)
 
 
+def test_online_dump_confg():
+    cfg = DetConfig()
+    cfg.load_config_files(slot=2)
+    cfg.get_smurf_control(dump_configs=False)
+    config_dir = 'config_dump'
+    cfg.dump_configs(config_dir, clobber=True, dump_rogue_tree=True)


### PR DESCRIPTION
This PR resolves issue #43 by adding publish statements to the dump_configs function, and copying the pysmurf configs along with the other yaml files.

It has not yet been tested.