### PR TITLE
bases pub id off stream id

### DIFF
--- a/sodetlib/det_config.py
+++ b/sodetlib/det_config.py
@@ -461,10 +461,13 @@ class DetConfig:
         """
         import pysmurf.client
 
+        slot_cfg = self.sys['slots'][f'SLOT[{self.slot}]']
         if epics_root is None:
             epics_root = f'smurf_server_s{self.slot}'
         if smurfpub_id is None:
-            smurfpub_id = f'crate{self.sys["crate_id"]}_slot{self.slot}'
+            smurfpub_id = slot_cfg.get(
+                'stream_id', f'crate{self.sys["crate_id"]}slot{self.slot}'
+            )
         if dump_configs is None:
             dump_configs = self.dump
 


### PR DESCRIPTION
Has the detconfig system set the publisher id to the slot's `stream_id`, and changes the default so that it matches with the default stream-id in the smurf-streamer.

Stream-id's can be set in the sys-config file, for example: 
```
slots:
    SLOT[2]:
        stream_port: 4532
        stream_id: slot_2_id
        pysmurf_config: /config/pysmurf_config/experiment_ucsd_k2so_cc02-06_lbOnlyBay0.cfg
        device_config: $OCS_CONFIG_DIR/device_configs/dev_cfg_demo_test_s2.yaml
    SLOT[3]:
        stream_port: 4533
        stream_id: slot_3_id
        pysmurf_config: /config/pysmurf_config/experiment_ucsd_k2so_cc02-06_lbOnly_BothBays.cfg
        device_config: $OCS_CONFIG_DIR/device_configs/dev_cfg_s3.yaml
```
and this will set both the stream id and publisher id accordingly.