### PR TITLE
Adding det_ops file, with an sodetlib take_iv function

### DIFF
--- a/sodetlib/smurf_funcs/det_ops.py
+++ b/sodetlib/smurf_funcs/det_ops.py
@@ -65,7 +65,7 @@ def take_iv(S, bias_groups=None, wait_time=.1, bias=None,
         Full path to IV raw npy file.
     """        
     
-    n_bias_groups = 12 # SO UFMs have 12 bias groups
+    n_bias_groups = S._n_bias_groups # This is the number of bias groups that the cryocard has
     if bias_groups is None:
         bias_groups = np.arange(12) # SO UFMs have 12 bias groups
     bias_groups = np.array(bias_groups)
@@ -123,9 +123,8 @@ def take_iv(S, bias_groups=None, wait_time=.1, bias=None,
     iv_info['stop_time'] = stop_time
     iv_info['basename'] = basename
     iv_info['datafile'] = datafile
-    iv_info['bias_array'] = bias
-    iv_info['bias group'] = bias_groups
     iv_info['bias'] = bias
+    iv_info['bias group'] = bias_groups
     
     iv_info_fp = os.path.join(S.output_dir, basename + '_iv_info.npy')
  


### PR DESCRIPTION
Adding det_ops file, with a take_iv function in it. This is just the script to take IVs, not analyze them, and returns a human-readable iv_info yaml file that will be used for sodetlib IV analysis. It keeps the iv_raw npy file that the pysmurf function outputs in order to be compatible with the pysmurf IV analysis function, until our analysis is merged in to sodetlib.