### PR TITLE
Adding tunefile to iv_info dict

### DIFF
--- a/sodetlib/smurf_funcs/det_ops.py
+++ b/sodetlib/smurf_funcs/det_ops.py
@@ -143,6 +143,7 @@ def take_iv(S, bias_groups=None, wait_time=.1, bias=None,
     iv_info = {}
     iv_info['plot_dir'] = S.plot_dir
     iv_info['output_dir'] = S.output_dir
+    iv_info['tune_file'] = S.tune_file
     iv_info['R_sh'] = S.R_sh
     iv_info['bias_line_resistance'] = S.bias_line_resistance
     iv_info['high_low_ratio'] = S.high_low_current_ratio


### PR DESCRIPTION
Adding the tunefile to the iv_info dict when you run take_iv. This way, always know what the tune situation was when you took the IV, since the active tune isn't streamed in the header. 