### PR TITLE
Apply dev cfg

### DIFF
--- a/sodetlib/det_config.py
+++ b/sodetlib/det_config.py
@@ -6,6 +6,8 @@ import sys
 import time
 import shutil
 
+from sodetlib.smurf_funcs.smurf_ops import apply_dev_cfg
+
 class YamlReps:
     class FlowSeq(list):
         """Represents a list as a flow sequencey by default"""
@@ -464,9 +466,11 @@ class DetConfig:
 
         return outfiles
 
-    def get_smurf_control(self, offline=False, epics_root=None, smurfpub_id=None,
-                              make_logfile=False, setup=False, dump_configs=None,
-                              config_dir=None, **pysmurf_kwargs):
+    def get_smurf_control(self, offline=False, epics_root=None,
+                          smurfpub_id=None, make_logfile=False, setup=False,
+                          dump_configs=None, config_dir=None,
+                          apply_dev_configs=True, load_device_tune=True,
+                          **pysmurf_kwargs):
         """
         Creates pysmurf instance based off of configuration parameters.
         If not specified as keyword arguments ``epics_root`` and ``smurf_pub``
@@ -528,4 +532,9 @@ class DetConfig:
                     print("Warning! Being run in offline mode with no config "
                           f"directory specified! Writing to {config_dir}")
             self.dump_configs(config_dir)
+
+        if apply_dev_configs:
+            print("Applying device cfg parameters...")
+            apply_dev_cfg(S, self, load_tune=load_device_tune)
+
         return S

--- a/sodetlib/smurf_funcs/smurf_ops.py
+++ b/sodetlib/smurf_funcs/smurf_ops.py
@@ -712,7 +712,7 @@ def stream_g3_off(S, emulator=False):
     return sess_id
 
 
-def apply_dev_cfg(S, cfg):
+def apply_dev_cfg(S, cfg, load_tune=True):
     """
     Applies basic device config params (amplifier biases, attens, tone_powers)
     to a pysmurf instance based on the device cfg values. Note that this does
@@ -720,9 +720,11 @@ def apply_dev_cfg(S, cfg):
     tracking_setup.
     """
     S.set_amplifier_bias(
-            bias_hemt=cfg.exp['amp_hemt_Vg'], bias_50k=cfg.exp['amp_50k_Vg']
+        bias_hemt=cfg.dev.exp['amp_hemt_Vg'],
+        bias_50k=cfg.dev.exp['amp_50k_Vg']
     )
-    if cfg.dev.exp.get('tunefile') is not None:
+
+    if load_tune:
         S.load_tune(cfg.dev.exp['tunefile'])
 
     for b in S._bands:


### PR DESCRIPTION
This PR adds a function to apply device config parameters (amp biases, attens, tunefile) to a pysmurf instance. It changes the `cfg.get_smurf_control` function so that parameters are automatically set when the smurf control object is loaded. With this change we are enforcing that when there are duplicates between the pysmurf and device config files, device config params should take precedence.