### PR TITLE
removed nodir from pysmurf setup

### DIFF
--- a/scripts/setup_pysmurf.py
+++ b/scripts/setup_pysmurf.py
@@ -6,9 +6,9 @@ from sodetlib.det_config import DetConfig
 if __name__ == "__main__":
     cfg = DetConfig()
     cfg.parse_args()
-    S = cfg.get_smurf_control(setup=True, dump_configs=False, no_dir=True)
+    S = cfg.get_smurf_control(setup=True, dump_configs=True)
     S.set_stream_enable(0)
 
     print("Setting synthesis scale...")
     for band in S.bands:
-        S.set_synthesis_scale(band,0x1)
+        S.set_synthesis_scale(band, 0x1)


### PR DESCRIPTION
This change takes away the `no_dir` keyword argument from the pysmurf setup script. This should fix the error:
```
Configuring pysmurf
Configuring pysmurf on slot 2...
Warning! Not making output directories!This will break may things!
[ 2021-05-13 18:52:42 ]  Setting up...
[ 2021-05-13 18:52:42 ]  Toggling DACs
Traceback (most recent call last):
  File "/sodetlib/scripts/setup_pysmurf.py", line 9, in <module>
    S = cfg.get_smurf_control(setup=True, dump_configs=False, no_dir=True)
  File "/sodetlib/sodetlib/det_config.py", line 516, in get_smurf_control
    make_logfile=make_logfile, **pysmurf_kwargs)
  File "/usr/local/src/pysmurf/python/pysmurf/client/base/smurf_control.py", line 151, in __init__
    **kwargs)
  File "/usr/local/src/pysmurf/python/pysmurf/client/base/smurf_control.py", line 302, in initialize
    success = self.setup(payload_size=payload_size, **kwargs)
  File "/usr/local/src/pysmurf/python/pysmurf/client/base/smurf_control.py", line 409, in setup
    for bay in self.bays:
AttributeError: 'SmurfControl' object has no attribute 'bays'
Finished configuring pysmurf!
```
 which happens during `jackhammer hammer`. Though I submitted a fix for this directly to the pysmurf repo, somehow it was reverted and the no_dir arg clearly isn't being tested or supported by them, so it's easiest to just not use it here