### PR TITLE
Makes lms_gain key optional in get_tracking_kwargs

### DIFF
--- a/sodetlib/util.py
+++ b/sodetlib/util.py
@@ -51,7 +51,7 @@ def get_tracking_kwargs(S, cfg, band, kwargs=None):
     tk = {
         'reset_rate_khz': band_cfg['flux_ramp_rate_khz'],
         'lms_freq_hz': band_cfg['lms_freq_hz'],
-        'lms_gain': band_cfg['lms_gain'],
+        'lms_gain': band_cfg.get('lms_gain', 0),
         'fraction_full_scale': band_cfg['frac_pp'],
         'make_plot': True, 'show_plot': True, 'channel': [],
         'nsamp': 2**18, 'return_data': True,


### PR DESCRIPTION
As Katie pointed out in #74, lms_gain right now is a required key in get_tracking_kwargs, even though we don't really want to be manually setting it or optimizing it. This PR switches that so that the tracking_kwargs default to 0 if it's not present in the cfg file.  Resolves #74.