### PR TITLE
Change apply_dev_configs default

### DIFF
--- a/sodetlib/det_config.py
+++ b/sodetlib/det_config.py
@@ -472,7 +472,7 @@ class DetConfig:
     def get_smurf_control(self, offline=False, epics_root=None,
                           smurfpub_id=None, make_logfile=False, setup=False,
                           dump_configs=None, config_dir=None,
-                          apply_dev_configs=True, load_device_tune=True,
+                          apply_dev_configs=False, load_device_tune=True,
                           **pysmurf_kwargs):
         """
         Creates pysmurf instance based off of configuration parameters.


### PR DESCRIPTION
Having the apply_dev_configs argument True by default is a bit annoying, since it means any script that creates a pysmurf instance tries to load device cfg arguments, including the pysmurf setup script, streaming scripts, jackhammer pysmurf, etc. I think it is better to not do this by default so that the behavior of these essential scripts does not change.