### PR TITLE
Remove smurf funcs init module

### DIFF
--- a/scripts/run_tuning.py
+++ b/scripts/run_tuning.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 from sodetlib.det_config import DetConfig
-from sodetlib.smurf_funcs import find_and_tune_freq
+from sodetlib.smurf_funcs.smurf_ops import find_and_tune_freq
 
 
 if __name__ == '__main__':

--- a/sodetlib/smurf_funcs/__init__.py
+++ b/sodetlib/smurf_funcs/__init__.py
@@ -1,4 +1,0 @@
-"""Module containing smurf control functions"""
-
-from sodetlib.smurf_funcs.optimize_params import *
-from sodetlib.smurf_funcs.smurf_ops import *


### PR DESCRIPTION
This init module was causing some import errors, and I'm not convinced its necessary  and checked that it's not really used anywhere.