### PR TITLE
Adds publisher id to the data directory

### DIFF
--- a/sodetlib/det_config.py
+++ b/sodetlib/det_config.py
@@ -558,8 +558,10 @@ class DetConfig:
         if dump_configs:
             if config_dir is None:
                 if not offline:
-                    config_dir = os.path.join(S.base_dir, S.date, S.name,
-                                              'config', S.get_timestamp())
+                    config_dir = os.path.join(
+                        S.base_dir, S.date, smurfpub_id, S.name, 'config',
+                        S.get_timestamp(),
+                    )
 
                 else:
                     config_dir = os.path.join('config', S.get_timestamp())


### PR DESCRIPTION
This PR adds the publisher ID (which defaults to the stream-id) to the smurf data directory path. This makes sure that each slot has a unique data location and are not writing over each other's data files.  Resolves #136.  This should make the smurf data paths look like this:
```
/data/smurf_data/20210710/<pub-id>/20210710/1625896574/outputs
```
I know that the date is in the path twice, however this is the only way we can make this work without a PR to pysmurf, since pysmurf will always put the date after the set data_dir, and we require that the date comes before the publisher ID. I think we should merge this so that we remove the possibility of conflicting paths in between slots ASAP, but submit a PR to pysmurf that allows us to remove the second date directory.

This has not yet been tested, but I can test on the SAT in the upcoming week.