### PR TITLE
Small fixes

### DIFF
--- a/scripts/set_stream.py
+++ b/scripts/set_stream.py
@@ -21,7 +21,6 @@ if __name__ == '__main__':
     parser.add_argument('--epics-root', type=str, default=None)
     parser.add_argument('--skip-freq-mask', action='store_true')
     parser.add_argument('--apply-dev-cfg', action='store_true')
-    parser.add_argument('--dump-configs', action='store_true')
     args = cfg.parse_args(parser)
 
     S = cfg.get_smurf_control(

--- a/sodetlib/smurf_funcs/check_state.py
+++ b/sodetlib/smurf_funcs/check_state.py
@@ -49,6 +49,7 @@ class ChannelState:
         self.wls = np.full(NCHANS, np.nan)
         self.band_medians = np.full(NBANDS, np.nan)
         self.timestamp = None
+        self.sid = None
 
         if S is not None:
             self.timestamp = S.get_timestamp()
@@ -79,7 +80,8 @@ class ChannelState:
                 File where state is saved
         """
         general = {
-            'timestamp': self.timestamp
+            'sid': self.sid,
+            'timestamp': self.timestamp,
         }
         np.savez(
             path, enabled=self.enabled, wls=self.wls,
@@ -105,6 +107,7 @@ class ChannelState:
         self.save_path = path
         general = npz['general'].item()
         self.timestamp = general['timestamp']
+        self.sid = general.get('sid')
         return self
 
     def desc(self):
@@ -204,6 +207,7 @@ def get_channel_state(S, cfg):
     sid = smurf_ops.take_g3_data(S, 30)
     am = smurf_ops.load_session(cfg, sid)
     chan_state.set_channel_wls(am)
+    chan_state.sid = sid
 
     path = make_filename(S, 'channel_state.npz')
     chan_state.save(path)

--- a/sodetlib/smurf_funcs/optimize_params.py
+++ b/sodetlib/smurf_funcs/optimize_params.py
@@ -13,7 +13,6 @@ from scipy import interpolate
 import pickle as pkl
 import sodetlib.util as su
 import sodetlib.smurf_funcs as sf
-import sodetlib.smurf_funcs.smurf_ops as so
 from pysmurf.client.util.pub import set_action
 from tqdm.auto import tqdm
 
@@ -413,7 +412,7 @@ def plot_optimize_attens(S, summary, wlmax=1000, vmin=None, vmax=None):
             ax.set(ylim=(vmin, vmax))
 
         else:  # Do full 2d heat map
-            im = ax.pcolor(ucs, dcs, wls[band].T, vmin=vmin, vmax=vmax)
+            im = ax.pcolor(ucs, dcs, wls[i].T, vmin=vmin, vmax=vmax)
             ax.set(xlabel="UC atten", ylabel="DC atten", title=f"Band {band}")
             if i == 0:
                 fig.colorbar(im, label='Median White Noise [pA/rt(Hz)]',
@@ -533,11 +532,11 @@ def optimize_attens(S, cfg, bands, meas_time=10, uc_attens=None,
             # Take data
             atten_grid.append([uc_atten, dc_atten])
             start_times.append(time.time())
-            sid = so.take_g3_data(S, meas_time)
+            sid = sf.smurf_ops.take_g3_data(S, meas_time)
             sids.append(sid)
             stop_times.append(time.time())
 
-            am = so.load_session(cfg, sid)
+            am = sf.smurf_ops.load_session(cfg, sid)
             wls, band_meds = su.get_wls_from_am(am)
             for k, b in enumerate(bands):
                 wl_medians[k, i, j] = band_meds[b]


### PR DESCRIPTION
Here are some small changes and fixes made during the SAT1 cooldown. Wanted to clean up local changes and make sure they are committed.

1. bug fix in set_stream script removing duplicate argparse arg
2. Adds session-id to state object so white noise timestreams can be analyzed after
3. Bug fix in plot_optimize_atten
4. Quick fix for circular imports, but this will eventually be resolved fully by #155 