### PR TITLE
Iv upgrades

### DIFF
--- a/sodetlib/analysis/det_analysis.py
+++ b/sodetlib/analysis/det_analysis.py
@@ -827,7 +827,7 @@ def analyze_iv_and_save(S, cfg, iv_info_fp, phase, v_bias, mask,
     return outfile
 
 
-def iv_channel_plots(iv_info, iv_analyze, bands=None, chans=None,
+def iv_channel_plots(iv_analyze, bands=None, chans=None,
                      plot_dir=None, show_plot=False, save_plot=True,
                      S=None):
     """
@@ -836,9 +836,6 @@ def iv_channel_plots(iv_info, iv_analyze, bands=None, chans=None,
 
     Args
     ----
-    iv_info: dict
-        Dictionary loaded from iv_info.npy that contains information from
-        when IV curve was taken.
     iv_analyze: dict
         Dictionary generated that contains all fitted and calculated
         parameters from IV analysis.
@@ -863,6 +860,8 @@ def iv_channel_plots(iv_info, iv_analyze, bands=None, chans=None,
     plot_dir: str
         Filepath where plots are saved, if save_plot is True.
     """
+    iv_info = iv_analyze['metadata']['iv_info']
+    
     if plot_dir is None:
         plot_dir = iv_info['plot_dir']
 
@@ -978,7 +977,7 @@ def iv_channel_plots(iv_info, iv_analyze, bands=None, chans=None,
         return plot_dir
 
 
-def iv_summary_plots(iv_info, iv_analyze, Rn_bins=None, Psat_bins=None,
+def iv_summary_plots(iv_analyze, Rn_bins=None, Psat_bins=None,
                      plot_dir=None, show_plot=False, save_plot=True,
                      S=None):
     """
@@ -989,9 +988,6 @@ def iv_summary_plots(iv_info, iv_analyze, Rn_bins=None, Psat_bins=None,
 
     Args
     ----
-    iv_info: dict
-        Dictionary loaded from iv_info.npy that contains information from
-        when IV curve was taken.
     iv_analyze: dict
         Dictionary generated that contains all fitted and calculated
         parameters from IV analysis.
@@ -1010,6 +1006,8 @@ def iv_summary_plots(iv_info, iv_analyze, Rn_bins=None, Psat_bins=None,
     plot_dir: str
         Filepath where plots are saved, if save_plot is True.
     """
+    iv_info = iv_analyze['metadata']['iv_info']
+    
     if plot_dir is None:
         plot_dir = iv_info['plot_dir']
 

--- a/sodetlib/smurf_funcs/det_ops.py
+++ b/sodetlib/smurf_funcs/det_ops.py
@@ -226,7 +226,6 @@ def take_iv(
 
         if make_channel_plots:
             det_analysis.iv_channel_plots(
-                iv_info,
                 iv_analyze,
                 plot_dir=iv_info["plot_dir"],
                 show_plot=False,
@@ -236,7 +235,6 @@ def take_iv(
 
         if make_summary_plots:
             det_analysis.iv_summary_plots(
-                iv_info,
                 iv_analyze,
                 plot_dir=iv_info["plot_dir"],
                 show_plot=False,


### PR DESCRIPTION
I may have screwed up the commits a little, but this PR closes https://github.com/simonsobs/sodetlib/issues/156, https://github.com/simonsobs/sodetlib/issues/140, and half of https://github.com/simonsobs/sodetlib/issues/118. Fixes bug to deal with correct 90% Rn identification, adds iv_info and iv_analyze to dev cfg if desired (and dumps dev cfg), and adds run info about what parameters the IV was run with. It also updates the responsivity calculation in the IV to be in line with Max's correction, which doesn't have an assigned issue (even though we should have made one...). Also updates the defaults in take_iv to be useful and actually something that will work for ~most assemblies. Tested on SPB on K2SO, but no expectation that anything in here will break for a UFM.  