### PR TITLE
Decrease hemt minimum Vgs from -1.2 V to -1.8 V

### DIFF
--- a/sodetlib/smurf_funcs/optimize_params.py
+++ b/sodetlib/smurf_funcs/optimize_params.py
@@ -354,9 +354,9 @@ def optimize_bias(S, target_Id, vg_min, vg_max, amp_name, max_iter=30):
             return False
 
         if amp_name == 'hemt':
-            S.set_hemt_gate_voltage(Vg_next)
+            S.set_hemt_gate_voltage(Vg_next, override=True)
         else:
-            S.set_50k_amp_gate_voltage(Vg_next)
+            S.set_50k_amp_gate_voltage(Vg_next, override=True)
         time.sleep(0.2)
     su.cprint(f"Max allowed Vg iterations ({max_iter}) has been reached. "
               f"Unable to get target Id for {amp_name}.", False)

--- a/sodetlib/smurf_funcs/smurf_ops.py
+++ b/sodetlib/smurf_funcs/smurf_ops.py
@@ -599,7 +599,7 @@ def cryo_amp_check(S, cfg):
     # Optimize bias voltages
     if biased_hemt and biased_50K:
         cprint("Scanning hemt bias voltage", TermColors.HEADER)
-        Id_hemt_in_range = op.optimize_bias(S, amp_hemt_Id, -1.2, -0.6, 'hemt')
+        Id_hemt_in_range = op.optimize_bias(S, amp_hemt_Id, -1.8, -0.6, 'hemt')
         cprint("Scanning 50K bias voltage", TermColors.HEADER)
         Id_50K_in_range = op.optimize_bias(S, amp_50K_Id, -0.8, -0.3, '50K')
         time.sleep(0.2)


### PR DESCRIPTION
Resolves #77 
* I have regularly found -1.7 V necessary to optimally bias the hemt
* Include `override=True` kwarg, already used in S.set_amplifier_bias()
