### PR TITLE
Adds ability to set additional kwargs to register get and set cmds

### DIFF
--- a/sodetlib/util.py
+++ b/sodetlib/util.py
@@ -495,11 +495,11 @@ class _Register:
         self.S = S
         self.addr = S.epics_root + ":" + addr
 
-    def get(self):
-        return self.S._caget(self.addr)
+    def get(self, **kw):
+        return self.S._caget(self.addr, **kw)
 
-    def set(self, val):
-        self.S._caput(self.addr, val)
+    def set(self, val, **kw):
+        self.S._caput(self.addr, val, **kw)
 
 class Registers:
     """


### PR DESCRIPTION
Adds ability to set additional kwargs to register get and set cmds. This is required for the pysmurf-conctroller-agent's check state process to avoid retrying failed epics attempts.