### PR TITLE
Revise amplifier biasing functions to work with pysmurf v6, C04/C05 cryocards

### DIFF
--- a/docs/operations/setup.rst
+++ b/docs/operations/setup.rst
@@ -45,8 +45,9 @@ can be biased via smurf. Additionally, the C04/C05 cryocards allow the drain
 voltages to be specified, while for C02 cryocards these are fixed.
 
 The ``setup_amps`` function will first determine which revision cryocard is
-connected based on firmware version, and therefore how many amplifiers need
-to be biased. It then enables the amps / sets the drain voltages if necessary.
+connected based on firmware version, and therefore which amplifiers are able
+to be biased. To be biased, these amps must also be listed in the device cfg.
+It then enables the amps / sets the drain voltages if necessary.
 It then checks if the amps happen to already be
 biased properly. If not, the function will sweep the gate-voltage until it
 finds one that hits the target drain voltages specified in the device cfg. 

--- a/sodetlib/det_config.py
+++ b/sodetlib/det_config.py
@@ -39,10 +39,27 @@ exp_defaults = {
     'downsample_factor': 20, 'coupling_mode': 'dc', 'synthesis_scale': 1,
 
     # Amp stuff
-    "amp_50k_init_Vg": -0.5, "amp_hemt_init_Vg": -1.0, "amp_hemt_Id": 8.0,
-    "amp_50k_Id": 15.0, "amp_50k_Vg": None, "amp_hemt_Vg": None,
+    "amps_to_bias": ['hemt', 'hemt1', 'hemt2', '50k', '50k1', '50k2'],
     "amp_enable_wait_time": 10.0, "amp_step_wait_time": 0.2,
-    "amp_hemt_Id_tolerance": 0.2, "amp_50k_Id_tolerance": 0.2,
+
+    "amp_50k_init_gate_volt": -0.5, "amp_50k_drain_current": 15.0,
+    "amp_50k_gate_volt": None, "amp_50k_drain_current_tolerance": 0.2,
+    "amp_hemt_init_gate_volt": -1.0, "amp_hemt_drain_current": 8.0,
+    "amp_hemt_gate_volt": None, "amp_hemt_drain_current_tolerance": 0.2,
+
+    "amp_50k1_init_gate_volt": -0.5, "amp_50k1_drain_current": 15.0,
+    "amp_50k1_gate_volt": None, "amp_50k1_drain_current_tolerance": 0.2,
+    "amp_50k1_drain_volt": 4,
+    "amp_50k2_init_gate_volt": -0.5, "amp_50k2_drain_current": 15.0,
+    "amp_50k2_gate_volt": None, "amp_50k2_drain_current_tolerance": 0.2,
+    "amp_50k2_drain_volt": 4,
+
+    "amp_hemt1_init_gate_volt": -1.0, "amp_hemt1_drain_current": 8.0,
+    "amp_hemt1_gate_volt": None, "amp_hemt1_drain_current_tolerance": 0.2,
+    "amp_hemt1_drain_volt": 0.6,
+    "amp_hemt2_init_gate_volt": -1.0, "amp_hemt2_drain_current": 8.0,
+    "amp_hemt2_gate_volt": None, "amp_hemt2_drain_current_tolerance": 0.2,
+    "amp_hemt2_drain_volt": 0.6,
 
     # Find freq
     'res_amp_cut': 0.01, 'res_grad_cut': 0.01,


### PR DESCRIPTION
This also changes the names of entires in the configuration files to match those now used by pysmurf.
Addresses #239 