### PR TITLE
Changes `take_g3_data` to get session-id from `stream_g3_off`

### DIFF
--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -116,10 +116,9 @@ def take_g3_data(S, dur, **stream_kw):
     session_id : int
         Id used to read back stream data
     """
-    sid = stream_g3_on(S, **stream_kw)
+    stream_g3_on(S, **stream_kw)
     time.sleep(dur)
-    stream_g3_off(S, emulator=stream_kw.get('emulator', False))
-    return sid
+    return stream_g3_off(S, emulator=stream_kw.get('emulator', False))
 
 
 @set_action()
@@ -190,6 +189,14 @@ def stream_g3_off(S, emulator=False):
     """
     reg = Registers(S)
     sess_id = reg.g3_session_id.get()
+    if sess_id == 0:
+        S.log("Session-id returned 0! Will try to obtain from file path")
+        fpath = reg.g3_filepath.get()
+        try:
+            sess_id = int(os.path.basename(fpath).split('_')[0])
+        except Exception:
+            S.log("Could not extract session id from filepath! Setting to 0")
+            sess_id = 0
 
     if emulator:
         reg.source_enable.set(0)

--- a/sodetlib/util.py
+++ b/sodetlib/util.py
@@ -536,6 +536,7 @@ class Registers:
         'stream_tag': _sostream + "stream_tag",
         'open_g3stream': _sostream + "open_g3stream",
         'g3_session_id': _sofilewriter + "session_id",
+        'g3_filepath': _sofilewriter + "filepath",
         'debug_data': _sostream + "DebugData",
         'debug_meta': _sostream + "DebugMeta",
         'debug_builder': _sostream + "DebugBuilder",


### PR DESCRIPTION
If the session id returns 0, this will query the current filepath the streamer is writing to and will try to extract the session-id from the filepath. If that fails, then it will return 0.

Changing the session-id retrieval to `stream_g3_off` gets rid of any timing issues that may come from attempting to get the session-id before it is actually set.