### PR TITLE
Grad descent function

### DIFF
--- a/sodetlib/det_config.py
+++ b/sodetlib/det_config.py
@@ -66,7 +66,7 @@ exp_defaults = {
 
     # Tracking stuff
     "flux_ramp_rate_khz": 4, "init_frac_pp": 0.4, "nphi0": 5,
-    "f_ptp_range": [10, 200], "df_ptp_range": [0, 50], "r2_min": 0.9,
+    "f_ptp_range": [10, 200], "df_ptp_range": [0, 100], "r2_min": 0.9,
     "min_good_tracking_frac": 0.8,
     'feedback_start_frac': 0.02, 'feedback_end_frac': 0.98,
 
@@ -81,6 +81,15 @@ band_defaults = {
 
     # Band-specific tracking stuff
     "lms_gain": 0, "feedback_gain": 2048, "frac_pp": None, "lms_freq_hz": None,
+
+    # Gradient Descent Parameters
+    "gradientDescentMaxIters": 150,
+    "gradientDescentAverages": 2, 
+    "gradientDescentGain": 0.001,
+    "gradientDescentConvergeHz": 500,
+    "gradientDescentStepHz": 5000,
+    "gradientDescentMomentum": 1,
+    "gradientDescentBeta": 0.1
 }
 bg_defaults = {}
 

--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -4,6 +4,7 @@ import sodetlib as sdl
 from sodetlib.operations.tracking import relock_tracking_setup
 from sodetlib.operations import uxm_setup
 
+import matplotlib.pyplot as plt
 
 @sdl.set_action()
 def reload_tune(S, cfg, bands, setup_notches=False,
@@ -44,9 +45,6 @@ def reload_tune(S, cfg, bands, setup_notches=False,
         else:
             S.relock(band)
 
-        S.run_serial_gradient_descent(band)
-        S.run_serial_eta_scan(band)
-
     if setup_notches and update_cfg:
         # Update tunefile
         cfg.dev.update_experiment({'tunefile': S.tune_file}, update_file=True)
@@ -55,9 +53,158 @@ def reload_tune(S, cfg, bands, setup_notches=False,
 
 
 @sdl.set_action()
+def run_grad_descent_and_eta_scan(
+    S, cfg, bands=None, ignore_scan_in_progress=True, update_tune=True):
+    """
+    This function runs serial gradient and eta scan for each band.
+    Critically, it pulls in gradient descent tune parameters from the device
+    config and uses them to setup the grad descent operation before running.
+
+    Args
+    ----
+    S : SmurfControl
+        Pysmurf instance
+    cfg : DetConfig
+        Det config instance
+    bands : list, optional
+        List of bands to run on. Defaults to all 8
+    ignore_scan_in_progress : bool
+        In the event that a grad descent crashes, which is unfortunately common,
+        as poorly tuned values of gain may result runaway frequency estimates
+        and overflow errors, SMuRF leaves the system in a bad state with a
+        `scanInProgress` variable blocking all input. This argument will tell
+        this function to purposefully clear that register if it is set, allowing
+        you to run the procedure. If this is False and the scanInProgress
+        variable is found to be True, this will throw an error.
+    update_tune : bool
+        If this is set to True, the new resonance frequency and eta parameters
+        will be loaded into the smurf tune, and a new tunefile will be written
+        based on the new measurements.
+    """
+
+    if bands is None:
+        bands = np.arange(8)
+    bands = np.atleast_1d(bands)
+
+    for b in bands:
+        in_progress_reg = S._cryo_root(b) + 'etaScanInProgress'
+        if S._caget(in_progress_reg):
+            raise RuntimeError(
+                "Failed during grad descent -- scan already in progress"
+            )
+
+        bcfg = cfg.dev.bands[b]
+        S.set_gradient_descent_step_hz(b, bcfg['gradientDescentStepHz'])
+        S.set_gradient_descent_max_iters(b, bcfg['gradientDescentMaxIters'])
+        S.set_gradient_descent_gain(b, bcfg['gradientDescentGain'])
+        S.set_gradient_descent_converge_hz(b, bcfg['gradientDescentConvergeHz'])
+        S.set_gradient_descent_beta(b, bcfg['gradientDescentBeta'])
+
+        S.log(f"Running grad descent and eta scan on band {b}")
+
+        init_scale_array = S.get_amplitude_scale_array(b)
+        init_center_freq_array = S.get_center_frequency_array(b)
+        S.run_serial_gradient_descent(b)
+
+        if (S.get_amplitude_scale_array(b) != init_scale_array).any():
+            S.log("Grad descent errored out! Resetting state")
+            S.set_amplitude_scale_array(b, init_scale_array)
+            S.set_center_frequency_array(b, init_center_freq_array)
+            S._caput(in_progress_reg, 0)
+            raise RuntimeError(
+                "Failed during grad descent -- check smurf-streamer logs"
+            )
+
+        S.run_serial_eta_scan(b)
+
+        if update_tune:
+            # This basically does the inverse of what's in the relock function
+            band_center_mhz = S.get_band_center_mhz(b)
+            subband_offset = S.get_tone_frequency_offset_mhz(b)
+            center_freq_array = S.get_center_frequency_array(b)
+            eta_phase_array = S.get_eta_phase_array(b)
+            eta_mag_array = S.get_eta_mag_array(b)
+            res_freqs = band_center_mhz + subband_offset + center_freq_array
+
+            for res in S.freq_resp[b]['resonances'].values():
+                ch = res['channel']
+                f0 = res['freq']
+                # Pysmurf does this to ignore channels with bad freqs so I 
+                # guess we will too
+                for ll, hh in S._bad_mask:
+                    if ll < f0 < hh:
+                        ch = -1
+
+                res['freq'] = res_freqs[ch]
+                res['offset'] = center_freq_array[ch]
+                res['eta_phase'] = eta_phase_array[ch]
+                res['eta_scaled'] = eta_mag_array[ch]
+
+    if update_tune:
+        S.log("Saving tune!")
+        S.save_tune()
+        cfg.dev.exp['tunefile'] = S.tune_file
+        cfg.dev.update_file()
+
+
+def plot_channel_resonance(S, cfg, band, chan):
+    """
+    Measures and plots resonator properties for a single smurf channel.
+    This will perform a scan around the specified channel, and will plot the
+    resonance dip along with where smurf thinks the resonance frequency is.
+    This is very useful for debugging why a channel isn't reading out properly.
+
+    Args
+    -----
+    S : (SmurfControl)
+        pysmurf instance
+    cfg : (DetConfig)
+        DetConfig instance
+    band : (int)
+        smurf band number
+    chan : (int)
+        smurf channel number
+    """
+    sb = S.get_subband_from_channel(band, chan)
+    tone_power = cfg.dev.bands[band]['tone_power']
+    res_freq = S.channel_to_freq(band, chan)
+    center_freq_array = S.get_center_frequency_array(band)
+
+    fs, resp = S.full_band_ampl_sweep(0, [sb], tone_power, 2, n_step=256)
+    S.set_center_freq_array(band, center_freq_array)
+
+    fs = fs.ravel() + S.get_band_center_mhz(band)
+    resp = resp.ravel()
+    fs = fs[resp > 0]
+    resp = resp[resp > 0]
+
+    fig, axes = plt.subplots(2, 1, figsize=(10, 10))
+
+    # Res-dip plot
+    ax = axes[0]
+    ax.plot(fs, np.abs(resp))
+    ax = ax.twinx()
+    ax.plot(fs, np.angle(resp), color='C1')
+    ax.axvline(res_freq, color='grey', ls='--')
+
+    # Circ plot
+    eta_phase = S.get_eta_phase_array(band)[chan]
+    eta = np.exp(1.0j * eta_phase * (2*np.pi) / 360)
+    Q = np.real(resp * eta)
+    I = -np.imag(resp * eta)
+
+    ax.axvline(0, color='grey')
+    ax.axhline(0, color='grey')
+    ax.scatter(I, Q, c=np.abs(resp))
+    ax.scatter(np.real(resp), np.imag(resp), c=np.abs(resp), alpha=0.3)
+
+    return fig, axes
+
+
+@sdl.set_action()
 def uxm_relock(S, cfg, bands=None, disable_bad_chans=True, show_plots=False,
                setup_notches=False, new_master_assignment=False,
-               reset_rate_khz=None, nphi0=None):
+               reset_rate_khz=None, nphi0=None, skip_setup_amps=False):
     """
     Relocks resonators by running the following steps
 
@@ -124,13 +271,15 @@ def uxm_relock(S, cfg, bands=None, disable_bad_chans=True, show_plots=False,
     #############################################################
     # 2. Setup amps
     #############################################################
-    summary['timestamps'].append(('setup_amps', time.time()))
-    sdl.set_session_data(S, 'timestamps', summary['timestamps'])
-    success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
+    if not skip_setup_amps:
+        summary['timestamps'].append(('setup_amps', time.time()))
+        sdl.set_session_data(S, 'timestamps', summary['timestamps'])
+        success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
 
-    if not success:
-        return False, summary
-
+        if not success:
+            return False, summary
+    else:
+        print("Skipping amp setup")
     #############################################################
     # 3. Load tune
     #############################################################
@@ -143,6 +292,7 @@ def uxm_relock(S, cfg, bands=None, disable_bad_chans=True, show_plots=False,
     sdl.set_session_data(S, 'reload_tune', summary['reload_tune'])
     if not success:
         return False, summary
+
 
     #############################################################
     # 4. Tracking Setup

--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -54,7 +54,7 @@ def reload_tune(S, cfg, bands, setup_notches=False,
 
 @sdl.set_action()
 def run_grad_descent_and_eta_scan(
-    S, cfg, bands=None, ignore_scan_in_progress=True, update_tune=True):
+    S, cfg, bands=None, update_tune=True):
     """
     This function runs serial gradient and eta scan for each band.
     Critically, it pulls in gradient descent tune parameters from the device
@@ -68,14 +68,6 @@ def run_grad_descent_and_eta_scan(
         Det config instance
     bands : list, optional
         List of bands to run on. Defaults to all 8
-    ignore_scan_in_progress : bool
-        In the event that a grad descent crashes, which is unfortunately common,
-        as poorly tuned values of gain may result runaway frequency estimates
-        and overflow errors, SMuRF leaves the system in a bad state with a
-        `scanInProgress` variable blocking all input. This argument will tell
-        this function to purposefully clear that register if it is set, allowing
-        you to run the procedure. If this is False and the scanInProgress
-        variable is found to be True, this will throw an error.
     update_tune : bool
         If this is set to True, the new resonance frequency and eta parameters
         will be loaded into the smurf tune, and a new tunefile will be written

--- a/sodetlib/operations/uxm_setup.py
+++ b/sodetlib/operations/uxm_setup.py
@@ -79,7 +79,7 @@ def find_gate_voltage(S, target_Id, amp_name, vg_min=-2.0, vg_max=0,
 
 
 @sdl.set_action()
-def setup_amps(S, cfg, update_cfg=True):
+def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True):
     """
     Initial setup for 50k and hemt amplifiers. For C04/C05 cryocards, will first
     check if the drain voltages are set. Then checks if drain
@@ -104,6 +104,8 @@ def setup_amps(S, cfg, update_cfg=True):
         DetConfig instance
     update_cfg : bool
         If true, will update the device cfg and save the file.
+    enable_300K_LNA:
+        If true, will turn on the 300K LNAs.
     """
     sdl.pub_ocs_log(S, "Starting setup_amps")
 
@@ -158,7 +160,7 @@ def setup_amps(S, cfg, update_cfg=True):
         delta_Id = np.abs(amp_biases[f"{amp}_drain_current"] - exp[f"amp_{amp}_drain_current"])
         if delta_Id > exp[f'amp_{amp}_drain_current_tolerance']:
             S.log(f"{amp} current not within tolerance, scanning for correct gate voltage")
-            S.set_amp_gate_voltage(amp, exp[f'amp_{amp}_init_gate_volt'])
+            S.set_amp_gate_voltage(amp, exp[f'amp_{amp}_init_gate_volt'],override=True)
             success = find_gate_voltage(
                 S, exp[f"amp_{amp}_drain_current"], amp, wait_time=exp['amp_step_wait_time'],
                 id_tolerance=exp[f'amp_{amp}_drain_current_tolerance']
@@ -168,7 +170,10 @@ def setup_amps(S, cfg, update_cfg=True):
                 sdl.set_session_data(S, 'setup_amps_summary', summary)
                 S.C.write_ps_en(0)
                 return False, summary
-
+    # Turn on 300K LNAs
+    if enable_300K_LNA:
+        S.C.write_optical(0b11)
+        
     # Update device cfg
     biases = S.get_amplifier_biases()
     if update_cfg:
@@ -207,10 +212,16 @@ def setup_phase_delay(S, cfg, bands, update_cfg=True, modify_attens=True):
         'band_delay_us': [],
     }
     for b in bands:
+        #init_att_uc = S.get_att_uc(b)
+        #init_att_dc = S.get_att_dc(b)
+        #S.set_att_uc(b, 30)
+        #S.set_att_dc(b, 30)
         summary['bands'].append(int(b))
         band_delay_us, _ = S.estimate_phase_delay(b, make_plot=True, show_plot=False)
         band_delay_us = float(band_delay_us)
         summary['band_delay_us'].append(band_delay_us)
+        #S.set_att_uc(b, init_att_uc)
+        #S.set_att_dc(b, init_att_dc)
         if update_cfg:
             cfg.dev.bands[b].update({
                 'band_delay_us': band_delay_us
@@ -223,7 +234,7 @@ def setup_phase_delay(S, cfg, bands, update_cfg=True, modify_attens=True):
     return True, summary
 
 
-def estimate_uc_dc_atten(S, cfg, band, update_cfg=True):
+def estimate_uc_dc_atten(S, cfg, band, update_cfg=True, tone_power=None):
     """
     Provides an initial estimation of uc and dc attenuation for a band in order
     to get the band response at a particular frequency to be within a certain
@@ -257,14 +268,20 @@ def estimate_uc_dc_atten(S, cfg, band, update_cfg=True):
     resp_range = (0.1, 0.4)
     # Just look at 5 subbands after specified freq.
     sbs = np.arange(sb, sb + 5)
+    sbs = np.arange(250, 255)
     nread = 2
 
     success = False
     S.log(f"Estimating attens for band {band}")
+
+    if tone_power is None:
+        tone_power = cfg.dev.bands[band]['tone_power']
+
     while True:
         S.set_att_uc(band, att)
         S.set_att_dc(band, att)
 
+        S.log(f'tone_power: {tone_power}')
         _, resp = S.full_band_ampl_sweep(band, sbs, cfg.dev.bands[band]['tone_power'], nread)
         max_resp = np.max(np.abs(resp))
         S.log(f"att: {att}, max_resp: {max_resp}")
@@ -354,7 +371,8 @@ def setup_tune(S, cfg, bands, show_plots=False, update_cfg=True):
 
 
 @sdl.set_action()
-def uxm_setup(S, cfg, bands=None, show_plots=True, update_cfg=True):
+def uxm_setup(S, cfg, bands=None, show_plots=True, update_cfg=True,
+              skip_estimate_attens=False, skip_phase_delay=False): 
     """
     The goal of this function is to do a pysmurf setup completely from scratch,
     meaning no parameters will be pulled from the device cfg.
@@ -438,26 +456,28 @@ def uxm_setup(S, cfg, bands=None, show_plots=True, update_cfg=True):
     #############################################################
     # 3. Estimate Attens
     #############################################################
-    summary['timestamps'].append(('estimate_attens', time.time()))
-    sdl.set_session_data(S, 'timestamps', summary['timestamps'])
-    for band in bands:
-        bcfg = cfg.dev.bands[band]
-        if (bcfg['uc_att'] is None) or (bcfg['dc_att'] is None):
-            success = estimate_uc_dc_atten(S, cfg, band, update_cfg=update_cfg)
-            if not success:
-                sdl.pub_ocs_log(S, f"Failed to estimate attens on band {band}")
-                return False, summary
+    if not skip_estimate_attens:
+        summary['timestamps'].append(('estimate_attens', time.time()))
+        sdl.set_session_data(S, 'timestamps', summary['timestamps'])
+        for band in bands:
+            bcfg = cfg.dev.bands[band]
+            if (bcfg['uc_att'] is None) or (bcfg['dc_att'] is None):
+                success = estimate_uc_dc_atten(S, cfg, band, update_cfg=update_cfg)
+                if not success:
+                    sdl.pub_ocs_log(S, f"Failed to estimate attens on band {band}")
+                    return False, summary
 
     #############################################################
     # 4. Estimate Phase Delay
     #############################################################
-    summary['timestamps'].append(('setup_phase_delay', time.time()))
-    sdl.set_session_data(S, 'timestamps', summary['timestamps'])
-    success, summary['setup_phase_delay'] = setup_phase_delay(
-        S, cfg, bands, update_cfg=update_cfg)
-    if not success:
-        S.log("UXM Setup failed on setup phase delay step")
-        return False, summary
+    if not skip_phase_delay:
+        summary['timestamps'].append(('setup_phase_delay', time.time()))
+        sdl.set_session_data(S, 'timestamps', summary['timestamps'])
+        success, summary['setup_phase_delay'] = setup_phase_delay(
+            S, cfg, bands, update_cfg=update_cfg)
+        if not success:
+            S.log("UXM Setup failed on setup phase delay step")
+            return False, summary
 
     #############################################################
     # 5. Setup Tune


### PR DESCRIPTION
This PR adds two functions, described below. I think people should review this but I won't merge it in until the uxm_setup_changes branch is cleaned up and merged so Penn doesn't have to switch back and forth between branches.

## run_grad_descent_and_eta_scan

This is a wrapper around smurf's gradient descent and eta scan functions, and critically allows grad-descent parameters to be set using the device config.

When I was looking at tuning issues at Penn I found a few interesting things:
- The default `maxIters` parameter used by gradient is 15, which is way too small. It is not able to recover from shifts in the resonance frequency, unless the `gain` parameter is tuned really well for that particular system. Increasing this to ~100 or 150 makes gradient descent _much_ more consistent and much better at recovering from frequency error, even without touching other parameters
- Some very reasonable combinations of parameters break gradient descent in such a way that it turns off all tones and prevents you from running any other scan operations....

`run_grad_descent_and_eta_scan` will take grad-descent parameters from the device cfg, and will try recover from grad-descent errors when they happen. Additionally, if passed the `updated_tune` kwarg, it will update the smurf-tune object and write a new one with the new freqs and eta parameters.

Based on the tests run at penn yesterday I'm hopeful that this will solve tune-stability issues by making relock w/o setup notches work better.

## plot_channel_resonance

This takes a band and channel and will measure the freq response around just that channel, and present a plot like this:
![resonance](https://user-images.githubusercontent.com/4718487/190861819-9a9b7dcd-82d9-4c9f-b091-1261c17f3864.png)
which informs you of how close smurf's probe tone is to the actual resonance, and whether the eta parameter is correct. This is a powerful debugging tool, since it can point you to why a channel lost tracking or has high noise.

In the image above the curve looks kinda noisy because flux-ramp is on, but if you turn it off it will be identical to the data taken in setup-notches.