### PR TITLE
Add temporary logic for observations

### DIFF
--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -150,7 +150,8 @@ def stream_g3_on(S, make_freq_mask=True, emulator=False, tag='',
     # they always come from sorunlib/pysmurf-controller
     # if not running an operation, assume it's a stream
     if tag.split(',')[0] != "oper": 
-        tag = "obs,stream," + tag
+        if tag.split(',')[0] != "obs":
+            tag = "obs,stream," + tag
     
     reg = Registers(S)
 

--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -146,6 +146,12 @@ def stream_g3_on(S, make_freq_mask=True, emulator=False, tag='',
     session_id : int
         Id used to read back streamed data
     """
+    # TEMPORARY tag edit logic to make observations look like
+    # they always come from sorunlib/pysmurf-controller
+    # if not running an operation, assume it's a stream
+    if tag.split(',')[0] != "oper": 
+        tag = "obs,stream," + tag
+    
     reg = Registers(S)
 
     reg.pysmurf_action.set(S.pub._action)


### PR DESCRIPTION
I realized that while the operation tagging logic is "complete" in terms of I don't think we'll ever need to change it (beyond adding _more_ operations). It would be really nice to have some fake logic for observations while testing is going on in labs. I think technically we'll never _have_ to remove these lines, but we might want to for deployment (I expect this could add "observations" that really aren't observations). 

But having them now will help up build a more useful practice data set for bookbinding.