### PR TITLE
Update ocs version within Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get install -y \
     libopenblas-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/CMB-S4/spt3g_software.git
+RUN git clone https://github.com/CMB-S4/spt3g_software.git && cd spt3g_software && git checkout  5f30121395129de9c9a6af2976de8ba8e876b5a8
 RUN cd spt3g_software \
     && mkdir -p build \
     && cd build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN pip3 install ./sotodlib
 #################################################################
 # OCS Install
 #################################################################
-RUN git clone --branch v0.9.1 https://github.com/simonsobs/ocs.git
+RUN git clone --branch py36 https://github.com/simonsobs/ocs.git
 
 RUN pip3 install cryptography==3.3.2
 # RUN pip3 install -r ocs/requirements.txt


### PR DESCRIPTION
For the pysmurf-controller we need the newest version of ocs. I made a Python 3.6 branch for ocs based on the latest develop branch, so that'll have the latest changes (and need to be kept up to date in the future.) We're doing the same thing on socs at the moment. This installs that new py36 ocs branch, and also checks out spt3g before Python detection in 3.6 broke.