### PR TITLE
Fix docs builds in Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       uses: ammaraskar/sphinx-action@0.4
       with:
         docs-folder: "docs/"
-        pre-build-command: "pip3 install -r requirements.txt ."
+        pre-build-command: "pip3 install -r docs/requirements.txt ."
         build-command: "make html"
 
     - name: Deploy HTML

--- a/.github/workflows/test-sphinx-build.yml
+++ b/.github/workflows/test-sphinx-build.yml
@@ -15,5 +15,5 @@ jobs:
       uses: ammaraskar/sphinx-action@0.4
       with:
         docs-folder: "docs/"
-        pre-build-command: "pip3 install -r requirements.txt ."
+        pre-build-command: "pip3 install -r docs/requirements.txt ."
         build-command: "make html"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ autodoc_mock_imports = [
     'sotodlib',
     'sotodlib.io',
     'sotodlib.tod_ops.fft_ops',
+    'sotodlib.tod_ops.filters',
     'sotodlib.tod_ops',
     'sotodlib.core',
     'tqdm.auto'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/operations/complex_impedance.rst
+++ b/docs/operations/complex_impedance.rst
@@ -39,7 +39,7 @@ to the commanded bias) as a function of frequency.
 In order to remove parasitic contamination from the bias circuitry, we use
 measurements of the TES response while the detectors are in their
 superconducting and normal states to obtain the Thevenin equivalent voltage and
-impedance of the bias circuit (see :ref:`Lindeman et al.<References>`). The
+impedance of the bias circuit (see :ref:`Lindeman et al.<ci_ref>`). The
 equivalent voltage and impedance are given by:
 
 .. math::
@@ -130,15 +130,11 @@ API
    :members: analyze_seg, analyze_tods, get_ztes, fit_det_params,
              take_complex_impedance, take_complex_impedance_ob_sc
 
+.. _ci_ref:
 
 References
 ----------
 
-.. _ci_ref:
-Useful references:
- - `Irwin / Hilton chapter on Transition Edge Sensors <https://link.springer.com/chapter/10.1007/10933596_3>`_
- - `Lindeman on correcting for stray impedances <https://doi.org/10.1063/1.2723066>`_
- - `Nick Cothard's paper on CI vs bias steps for SO prototype dets <https://arxiv.org/abs/2012.08547>`_
-
-
-
+- `Irwin / Hilton chapter on Transition Edge Sensors <https://link.springer.com/chapter/10.1007/10933596_3>`_
+- `Lindeman on correcting for stray impedances <https://doi.org/10.1063/1.2723066>`_
+- `Nick Cothard's paper on CI vs bias steps for SO prototype dets <https://arxiv.org/abs/2012.08547>`_

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,8 @@
 jinja2<3.1
 sphinx_rtd_theme==1.0.0
 sphinx-argparse==0.3.1
+
+numpy
+scipy
+PyYAML
+matplotlib


### PR DESCRIPTION
I noticed these were failing for #316 and thought I'd fix.

pyfftw installation is failing for some reason in the CI environment. I'm not sure what's going on there, but the module isn't needed to build the docs. I've added the minimum modules required to the docs requirements file, and have redirected the workflows to install that instead of the module's full requirements file.

Also fixed a couple of build warnings while I was at it.