### PR TITLE
adds compatibility to sodetlib for `am.det_info`

### DIFF
--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -96,7 +96,12 @@ def load_session(stream_id, session_id, idx=None,
         raise FileNotFoundError(
             f"Could not find files for {(stream_id, session_id)}"
         )
-    return load_smurf.load_file(files, show_pb=show_pb, **kwargs)
+    am =  load_smurf.load_file(files, show_pb=show_pb, **kwargs)
+
+    if 'ch_info' not in am._fields:
+        am.wrap('ch_info', am.det_info.smurf)
+
+    return am
 
 
 @set_action()


### PR DESCRIPTION
Newer versions of sotodlib replace `am.ch_info` with `am.det_info`, where all the band/channel info is now in `am.det_info.smurf`. I'm testing sodetlib/smurf dockers that are built on python3.8 and newer versions of the SO software stack, so this is something that has come up and breaks some sodetlib functions.

This PR changes the `load_session` function so that it will check if `ch_info` exists, and if it doesn't will wrap `am.det_info.smurf`  with the name `ch_info` so sodetlib functions remain compatible. We should probably transition to using `am.det_info.smurf`, but I think this is an important temporary measure