### PR TITLE
bump dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM simonsobs/so_smurf_base:v0.0.2
+FROM simonsobs/so_smurf_base:v0.0.2-1-g4a75f5b
 
 #################################################################
 # sodetlib Install


### PR DESCRIPTION
Bump so_smurf_docker version. This fixes issues the error we were seeing before, and has been tested on the SAT1 system