### PR TITLE
Removes pysmurf type hints

### DIFF
--- a/sodetlib/operations/optimize.py
+++ b/sodetlib/operations/optimize.py
@@ -5,7 +5,6 @@ import numpy as np
 import time
 from tqdm.auto import tqdm
 import matplotlib.pyplot as plt
-from pysmurf.client.base.smurf_control import SmurfControl
 
 
 def find_min_total_atten(S, band, atten_offset=2):
@@ -41,7 +40,7 @@ def find_min_total_atten(S, band, atten_offset=2):
     return False
 
 @sdl.set_action()
-def optimize_band_atten(S: SmurfControl, cfg, band, meas_time=30, 
+def optimize_band_atten(S, cfg, band, meas_time=30, 
     total_att=None, ucs=None, show_pb=False, bgs=None, full_tune=False):
     """
     This function will optimize values for uc and dc attenuators. First, it

--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -6,9 +6,6 @@ from sodetlib.operations import uxm_setup
 
 import matplotlib.pyplot as plt
 import os
-if not os.environ.get('NO_PYSMURF', False):
-    from pysmurf.client.base.smurf_control import SmurfControl
-
 
 
 @sdl.set_action()
@@ -260,7 +257,7 @@ def plot_channel_resonance(S, cfg, band, chan):
 
 @sdl.set_action()
 def uxm_relock(
-    S: SmurfControl, cfg, bands=None, show_plots=False,
+    S, cfg, bands=None, show_plots=False,
     setup_notches=False, new_master_assignment=False, reset_rate_khz=None,
     nphi0=None, skip_setup_amps=False):
     """

--- a/sodetlib/quality_control.py
+++ b/sodetlib/quality_control.py
@@ -1,7 +1,6 @@
 import sodetlib as sdl
 import numpy as np
 import time
-from pysmurf.client.base.smurf_control import SmurfControl
 
 def check_packet_loss(Ss, cfgs, dur=10, fr_khz=4, nchans=2000, slots=None):
     """
@@ -69,8 +68,7 @@ def check_packet_loss(Ss, cfgs, dur=10, fr_khz=4, nchans=2000, slots=None):
     return ams, res
 
 @sdl.set_action()
-def measure_bias_line_resistances(
-    S: SmurfControl, cfg, vstep=0.001, bgs=None, sleep_time=2.0):
+def measure_bias_line_resistances(S, cfg, vstep=0.001, bgs=None, sleep_time=2.0):
     """
     Function to measure the bias line resistance and high-low-current-ratio for
     each bias group. This needs to be run with the smurf hooked up to the


### PR DESCRIPTION
I added these type hints since it is helpful for development + autocomplete, however it seems like they cause some import errors in certain environments like the pysmurf-controller, so probably best to remove.