### PR TITLE
Switches overbias_dets to using set_current_mode

### DIFF
--- a/sodetlib/util.py
+++ b/sodetlib/util.py
@@ -856,10 +856,10 @@ def overbias_dets(S, cfg, bias_groups=None, biases=None, cool_wait=None,
 
     for bg in bias_groups:
         if biases is not None:
-            _bias = biases[bg]
+            bias = biases[bg]
         else:
-            _bias = cfg.dev.bias_groups[bg]['cool_voltage']
-        S.set_tes_bias_bipolar(bg, _bias)
+            bias = cfg.dev.bias_groups[bg]['cool_voltage']
+        S.set_tes_bias_bipolar(bg, bias)
 
     lcm_bgs = np.where(high_current_mode)[0]
     set_current_mode(S, lcm_bgs, 0, const_current=False)

--- a/sodetlib/util.py
+++ b/sodetlib/util.py
@@ -854,15 +854,14 @@ def overbias_dets(S, cfg, bias_groups=None, biases=None, cool_wait=None,
     S.log(f"Waiting at ob volt for {wait_time} sec")
     time.sleep(wait_time)
 
-    _biases = np.zeros_like(S.get_tes_bias_bipolar_array())
     for bg in bias_groups:
         if biases is not None:
-            _biases[bg] = biases[bg]
+            _bias = biases[bg]
         else:
-            _biases[bg] = cfg.dev.bias_groups[bg]['cool_voltage']
+            _bias = cfg.dev.bias_groups[bg]['cool_voltage']
+        S.set_tes_bias_bipolar(bg, _bias)
 
     lcm_bgs = np.where(high_current_mode)[0]
-    S.set_tes_bias_bipolar_array(_biases)
     set_current_mode(S, lcm_bgs, 0, const_current=False)
 
     if cool_wait is not None:

--- a/sodetlib/util.py
+++ b/sodetlib/util.py
@@ -844,6 +844,7 @@ def overbias_dets(S, cfg, bias_groups=None, biases=None, cool_wait=None,
 
     if isinstance(high_current_mode, (bool, int)):
         high_current_mode = [high_current_mode for _ in range(12)]
+    high_current_mode = np.atleast_1d(high_current_mode)
 
     S.log("Overbiasing Detectors")
     set_current_mode(S, bias_groups, 1, const_current=False)
@@ -861,7 +862,7 @@ def overbias_dets(S, cfg, bias_groups=None, biases=None, cool_wait=None,
             bias = cfg.dev.bias_groups[bg]['cool_voltage']
         S.set_tes_bias_bipolar(bg, bias)
 
-    lcm_bgs = np.where(high_current_mode)[0]
+    lcm_bgs = np.where(~high_current_mode)[0]
     set_current_mode(S, lcm_bgs, 0, const_current=False)
 
     if cool_wait is not None:


### PR DESCRIPTION
This changes the `overbias_dets` function to use `set_current_mode` instead of looping through bias lines switching individually. I haven't tested this, but @kmharrington it would be great if we could test on the latrt and confirm it fixes the heating issues.