### PR TITLE
Splits 'oper' tags from user-set g3 tags

### DIFF
--- a/sodetlib/noise.py
+++ b/sodetlib/noise.py
@@ -510,7 +510,7 @@ def take_noise(S, cfg, acq_time=30, plot_band_summary=True, nbins=40,
         passing low-f requirement (i.e. fknee set by wl = 65pA/rtHz and
         slope must be <= 1/f^{1/2} in the ASD)
     g3_tag: string, optional
-        if not None, overrides default tag "oper,noise" sent to g3 file
+        Tag to be attached to g3 stream 
     
     Returns
     -------
@@ -543,9 +543,7 @@ def take_noise(S, cfg, acq_time=30, plot_band_summary=True, nbins=40,
     if save_dir is None:
         save_dir = S.plot_dir
 
-    if g3_tag is None:
-        g3_tag = "oper,noise"
-    sid = sdl.take_g3_data(S, acq_time, tag=g3_tag)
+    sid = sdl.take_g3_data(S, acq_time, tag=g3_tag, oper='noise')
     am = sdl.load_session(cfg.stream_id, sid, base_dir=cfg.sys['g3_dir'])
     ctime = int(am.timestamps[0])
     noisedict = get_noise_params(am, wl_f_range=wl_f_range, fit=fit,

--- a/sodetlib/noise.py
+++ b/sodetlib/noise.py
@@ -543,7 +543,7 @@ def take_noise(S, cfg, acq_time=30, plot_band_summary=True, nbins=40,
     if save_dir is None:
         save_dir = S.plot_dir
 
-    sid = sdl.take_g3_data(S, acq_time, tag=g3_tag, oper='noise')
+    sid = sdl.take_g3_data(S, acq_time, tag=g3_tag, subtype='noise')
     am = sdl.load_session(cfg.stream_id, sid, base_dir=cfg.sys['g3_dir'])
     ctime = int(am.timestamps[0])
     noisedict = get_noise_params(am, wl_f_range=wl_f_range, fit=fit,

--- a/sodetlib/operations/bias_steps.py
+++ b/sodetlib/operations/bias_steps.py
@@ -1076,7 +1076,7 @@ def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
                     nsteps=20, high_current_mode=True, hcm_wait_time=3,
                     run_analysis=True, analysis_kwargs=None, dacs='pos',
                     use_waveform=True, channel_mask=None, g3_tag=None,
-                    stream_subtype=None):
+                    stream_subtype='bias_steps'):
     """
     Takes bias step data at the current DC voltage. Assumes bias lines
     are already in low-current mode (if they are in high-current this will
@@ -1126,16 +1126,13 @@ def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
             Mask containing absolute smurf-channels to write to disk
         g3_tag: string, optional
             Tag to attach to g3 stream.
-        oper : optional, string
-            Operation tag to attach to G3Stream. If left blank, this will default
-            to 'bias_steps'.
+        stream_subtype : optional, string
+            Stream subtype for this operation. This will default to 'bias_steps'.
     """
     if bgs is None:
         bgs = cfg.dev.exp['active_bgs']
     bgs = np.atleast_1d(bgs)
 
-    if stream_subtype is None:
-        stream_subtype = 'bias_steps'
     # Adds to account for steps that may be cut in analysis
     nsteps += 4
 

--- a/sodetlib/operations/bias_steps.py
+++ b/sodetlib/operations/bias_steps.py
@@ -1056,7 +1056,7 @@ def take_bgmap(S, cfg, bgs=None, dc_voltage=0.3, step_voltage=0.01,
         S, cfg, bgs, step_voltage=step_voltage, step_duration=step_duration,
         nsteps=nsteps, high_current_mode=high_current_mode,
         hcm_wait_time=hcm_wait_time, run_analysis=True, dacs=dacs,
-        use_waveform=use_waveform, g3_tag=g3_tag, oper='bgmap',
+        use_waveform=use_waveform, g3_tag=g3_tag, stream_subtype='bgmap',
         analysis_kwargs=_analysis_kwargs
     )
 
@@ -1075,7 +1075,8 @@ def take_bgmap(S, cfg, bgs=None, dc_voltage=0.3, step_voltage=0.01,
 def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
                     nsteps=20, high_current_mode=True, hcm_wait_time=3,
                     run_analysis=True, analysis_kwargs=None, dacs='pos',
-                    use_waveform=True, channel_mask=None, g3_tag=None, oper=None):
+                    use_waveform=True, channel_mask=None, g3_tag=None,
+                    stream_subtype=None):
     """
     Takes bias step data at the current DC voltage. Assumes bias lines
     are already in low-current mode (if they are in high-current this will
@@ -1133,8 +1134,8 @@ def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
         bgs = cfg.dev.exp['active_bgs']
     bgs = np.atleast_1d(bgs)
 
-    if oper is None:
-        oper = 'bias_steps'
+    if stream_subtype is None:
+        stream_subtype = 'bias_steps'
     # Adds to account for steps that may be cut in analysis
     nsteps += 4
 
@@ -1166,7 +1167,7 @@ def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
 
         bsa.sid = sdl.stream_g3_on(
             S, tag=g3_tag, channel_mask=channel_mask, downsample_factor=1,
-            filter_disable=True, oper=oper
+            filter_disable=True, subtype=stream_subtype
         )
 
         bsa.start = time.time()

--- a/sodetlib/operations/bias_steps.py
+++ b/sodetlib/operations/bias_steps.py
@@ -1035,8 +1035,7 @@ def take_bgmap(S, cfg, bgs=None, dc_voltage=0.3, step_voltage=0.01,
             Keyword arguments to be passed to the BiasStepAnalysis run_analysis
             function.
         g3_tag: string, optional
-            if not None, overrides the default tag "oper,bgmap" sent to the g3
-            file
+            Tag to attach to g3 stream.
     """
     if bgs is None:
         bgs = cfg.dev.exp['active_bgs']
@@ -1044,9 +1043,6 @@ def take_bgmap(S, cfg, bgs=None, dc_voltage=0.3, step_voltage=0.01,
 
     if analysis_kwargs is None:
         analysis_kwargs = {}
-
-    if g3_tag is None:
-        g3_tag = "oper,bgmap"
 
     for bg in bgs:
         S.set_tes_bias_bipolar(bg, dc_voltage)
@@ -1060,7 +1056,7 @@ def take_bgmap(S, cfg, bgs=None, dc_voltage=0.3, step_voltage=0.01,
         S, cfg, bgs, step_voltage=step_voltage, step_duration=step_duration,
         nsteps=nsteps, high_current_mode=high_current_mode,
         hcm_wait_time=hcm_wait_time, run_analysis=True, dacs=dacs,
-        use_waveform=use_waveform, g3_tag=g3_tag,
+        use_waveform=use_waveform, g3_tag=g3_tag, oper='bgmap',
         analysis_kwargs=_analysis_kwargs
     )
 
@@ -1079,7 +1075,7 @@ def take_bgmap(S, cfg, bgs=None, dc_voltage=0.3, step_voltage=0.01,
 def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
                     nsteps=20, high_current_mode=True, hcm_wait_time=3,
                     run_analysis=True, analysis_kwargs=None, dacs='pos',
-                    use_waveform=True, channel_mask=None, g3_tag=None):
+                    use_waveform=True, channel_mask=None, g3_tag=None, oper=None):
     """
     Takes bias step data at the current DC voltage. Assumes bias lines
     are already in low-current mode (if they are in high-current this will
@@ -1128,16 +1124,17 @@ def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
         channel_mask : np.ndarray, optional
             Mask containing absolute smurf-channels to write to disk
         g3_tag: string, optional
-            if not None, overrides the default tag "oper,bias_steps" sent to the 
-            g3 file
+            Tag to attach to g3 stream.
+        oper : optional, string
+            Operation tag to attach to G3Stream. If left blank, this will default
+            to 'bias_steps'.
     """
     if bgs is None:
         bgs = cfg.dev.exp['active_bgs']
     bgs = np.atleast_1d(bgs)
 
-    if g3_tag is None:
-        g3_tag = "oper,bias_steps"
-
+    if oper is None:
+        oper = 'bias_steps'
     # Adds to account for steps that may be cut in analysis
     nsteps += 4
 
@@ -1169,7 +1166,7 @@ def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
 
         bsa.sid = sdl.stream_g3_on(
             S, tag=g3_tag, channel_mask=channel_mask, downsample_factor=1,
-            filter_disable=True
+            filter_disable=True, oper=oper
         )
 
         bsa.start = time.time()

--- a/sodetlib/operations/complex_impedance.py
+++ b/sodetlib/operations/complex_impedance.py
@@ -559,7 +559,8 @@ def take_complex_impedance(
             m = ds.bgmap == bg
             channel_mask = ds.bands[m] * S.get_number_channels() + ds.channels[m]
 
-            ds.sids[bg] = sdl.stream_g3_on(S, channel_mask=channel_mask)
+            ds.sids[bg] = sdl.stream_g3_on(
+                S, channel_mask=channel_mask, oper='complex_impedance')
             for j, freq in enumerate(freqs):
                 meas_time = min(1./freq * nperiods, max_meas_time)
                 S.log(f"Tickle with bg={bg}, freq={freq}")

--- a/sodetlib/operations/complex_impedance.py
+++ b/sodetlib/operations/complex_impedance.py
@@ -560,7 +560,7 @@ def take_complex_impedance(
             channel_mask = ds.bands[m] * S.get_number_channels() + ds.channels[m]
 
             ds.sids[bg] = sdl.stream_g3_on(
-                S, channel_mask=channel_mask, oper='complex_impedance')
+                S, channel_mask=channel_mask, subtype='complex_impedance')
             for j, freq in enumerate(freqs):
                 meas_time = min(1./freq * nperiods, max_meas_time)
                 S.log(f"Tickle with bg={bg}, freq={freq}")

--- a/sodetlib/operations/iv.py
+++ b/sodetlib/operations/iv.py
@@ -623,7 +623,7 @@ def take_iv(S, cfg, bias_groups=None, overbias_voltage=18.0, overbias_wait=5.0,
     if high_current_mode:
         biases /= S.high_low_current_ratio
     try:
-        sid = sdl.stream_g3_on(S, tag=g3_tag, oper='iv')
+        sid = sdl.stream_g3_on(S, tag=g3_tag, subtype='iv')
         if run_serially:
             for bg in bias_groups:
                 overbias_and_sweep(bg, cool_voltage=cool_voltage)

--- a/sodetlib/operations/iv.py
+++ b/sodetlib/operations/iv.py
@@ -574,9 +574,6 @@ def take_iv(S, cfg, bias_groups=None, overbias_voltage=18.0, overbias_wait=5.0,
         bias_groups = cfg.dev.exp['active_bgs']
     bias_groups = np.atleast_1d(bias_groups)
 
-    if g3_tag is None:
-        g3_tag = "oper,iv"
-
     if biases is None:
         biases = np.arange(bias_high, bias_low - bias_step, -bias_step)
     # Make sure biases is in decreasing order for run function
@@ -626,7 +623,7 @@ def take_iv(S, cfg, bias_groups=None, overbias_voltage=18.0, overbias_wait=5.0,
     if high_current_mode:
         biases /= S.high_low_current_ratio
     try:
-        sid = sdl.stream_g3_on(S, tag=g3_tag)
+        sid = sdl.stream_g3_on(S, tag=g3_tag, oper='iv')
         if run_serially:
             for bg in bias_groups:
                 overbias_and_sweep(bg, cool_voltage=cool_voltage)

--- a/sodetlib/quality_control.py
+++ b/sodetlib/quality_control.py
@@ -42,7 +42,7 @@ def check_packet_loss(Ss, cfgs, dur=10, fr_khz=4, nchans=2000, slots=None):
         S.flux_ramp_setup(fr_khz, 0.4, band=0)
         sdl.stream_g3_on(
             S, channel_mask=np.arange(nchans), downsample_factor=1,
-            oper='check_packet_loss'
+            subtype='check_packet_loss'
         )
 
     time.sleep(dur)
@@ -112,7 +112,7 @@ def measure_bias_line_resistances(
         t1 = time.time()
         return (t0, t1)
 
-    sdl.stream_g3_on(S, oper='measure_bias_line_resistance')
+    sdl.stream_g3_on(S, subtype='measure_bias_line_resistance')
     time.sleep(0.5)
 
     segs.append(take_step(vb_low, sleep_time, wait_time=0.5))

--- a/sodetlib/quality_control.py
+++ b/sodetlib/quality_control.py
@@ -41,7 +41,8 @@ def check_packet_loss(Ss, cfgs, dur=10, fr_khz=4, nchans=2000, slots=None):
         S = Ss[s]
         S.flux_ramp_setup(fr_khz, 0.4, band=0)
         sdl.stream_g3_on(
-            S, channel_mask=np.arange(nchans), downsample_factor=1
+            S, channel_mask=np.arange(nchans), downsample_factor=1,
+            oper='check_packet_loss'
         )
 
     time.sleep(dur)
@@ -111,7 +112,7 @@ def measure_bias_line_resistances(
         t1 = time.time()
         return (t0, t1)
 
-    sdl.stream_g3_on(S)
+    sdl.stream_g3_on(S, oper='measure_bias_line_resistance')
     time.sleep(0.5)
 
     segs.append(take_step(vb_low, sleep_time, wait_time=0.5))

--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -130,7 +130,7 @@ def take_g3_data(S, dur, **stream_kw):
 def stream_g3_on(S, make_freq_mask=True, emulator=False, tag=None,
                  channel_mask=None, filter_wait_time=2, make_datfile=False,
                  downsample_factor=None, downsample_mode=None,
-                 filter_disable=False, oper=None):
+                 filter_disable=False, stream_type=None, subtype=None):
     """
     Starts the G3 data-stream. Returns the session-id corresponding with the
     data stream.
@@ -170,14 +170,19 @@ def stream_g3_on(S, make_freq_mask=True, emulator=False, tag=None,
     session_id : int
         Id used to read back streamed data
     """
+    if subtype is None:
+        subtype = 'stream'
 
-    if oper is None:
-        tags = 'obs,stream'
-    else:
-        tags = f'oper,{oper}'
+    if stream_type is None:
+        if subtype in ['stream', 'cmb', 'cal']:
+            stream_type = 'obs'
+        else:
+            stream_type = 'oper'
 
+    tags = f'{stream_type},{subtype}'
     if tag is not None:
         tags += ',' + tag
+
     
     reg = Registers(S)
 

--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -130,7 +130,7 @@ def take_g3_data(S, dur, **stream_kw):
 def stream_g3_on(S, make_freq_mask=True, emulator=False, tag=None,
                  channel_mask=None, filter_wait_time=2, make_datfile=False,
                  downsample_factor=None, downsample_mode=None,
-                 filter_disable=False, stream_type=None, subtype=None):
+                 filter_disable=False, stream_type=None, subtype='stream'):
     """
     Starts the G3 data-stream. Returns the session-id corresponding with the
     data stream.
@@ -161,18 +161,18 @@ def stream_g3_on(S, make_freq_mask=True, emulator=False, tag=None,
         this will be pulled from the device cfg.
     filter_disable : bool
         If true, will disable the downsample filter before streaming.
-    oper : optional(string)
-        operation tag. If set, the g3-tag will be `oper,<oper>,<tag>`. If None,
-        the g3-tag will be `obs,stream,<tag>.
+    stream_type : optional(string)
+        Type of stream. This should either be "obs" or "oper". If None,
+        it will be determined based off of the subtype. ('stream', 'cmb', and
+        'cal', will automatically be set to 'obs' type)
+    subtype : optional(string)
+        Stream subtype. This defaults to 'stream'.
 
     Return
     -------
     session_id : int
         Id used to read back streamed data
     """
-    if subtype is None:
-        subtype = 'stream'
-
     if stream_type is None:
         if subtype in ['stream', 'cmb', 'cal']:
             stream_type = 'obs'

--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -127,10 +127,10 @@ def take_g3_data(S, dur, **stream_kw):
 
 
 @set_action()
-def stream_g3_on(S, make_freq_mask=True, emulator=False, tag='',
+def stream_g3_on(S, make_freq_mask=True, emulator=False, tag=None,
                  channel_mask=None, filter_wait_time=2, make_datfile=False,
                  downsample_factor=None, downsample_mode=None,
-                 filter_disable=False):
+                 filter_disable=False, oper=None):
     """
     Starts the G3 data-stream. Returns the session-id corresponding with the
     data stream.
@@ -144,24 +144,46 @@ def stream_g3_on(S, make_freq_mask=True, emulator=False, tag='',
     emulator : bool
         If True, will enable the emulator source data-generator. Defaults to
         False.
+    tag : optional(string)
+        If set, this will attach the tag to the g3 stream
+    channel_mask : optional(list)
+        List of channels to stream. If None, this will stream all channels with
+        a probe tone
+    filter_wait_time : float
+        Seconds to wait after resetting the filter before writing data to disk
+    make_datfile bool
+        If True, will create a datfile
+    downsample_factor : optional(int)
+        Downsample factor. If None, this will be pulled from the device
+        cfg.
+    downsample_mode : optional(string)
+        Downsample mode, can either be 'internal' or 'external'. If not set,
+        this will be pulled from the device cfg.
+    filter_disable : bool
+        If true, will disable the downsample filter before streaming.
+    oper : optional(string)
+        operation tag. If set, the g3-tag will be `oper,<oper>,<tag>`. If None,
+        the g3-tag will be `obs,stream,<tag>.
 
     Return
     -------
     session_id : int
         Id used to read back streamed data
     """
-    # TEMPORARY tag edit logic to make observations look like
-    # they always come from sorunlib/pysmurf-controller
-    # if not running an operation, assume it's a stream
-    if tag.split(',')[0] != "oper": 
-        if tag.split(',')[0] != "obs":
-            tag = "obs,stream," + tag
+
+    if oper is None:
+        tags = 'obs,stream'
+    else:
+        tags = f'oper,{oper}'
+
+    if tag is not None:
+        tags += ',' + tag
     
     reg = Registers(S)
 
     reg.pysmurf_action.set(S.pub._action)
     reg.pysmurf_action_timestamp.set(S.pub._action_ts)
-    reg.stream_tag.set(tag)
+    reg.stream_tag.set(tags)
 
     cfg = S._sodetlib_cfg
     if downsample_mode is None:


### PR DESCRIPTION
For data packaging, we want to be able to pass tags in from the pysmurf-controller. As it is currently implemented, user-provided tags will overwrite the `oper` tags set by various sodetlib operations. To fix this, adds a separate `oper` keyword to the `stream_data_on` function, which is used to determine the initial part of g3 tag (i.e. `oper,iv` or `obs,stream`). The user-provided tag will be appended to the end.

This needs to be tested, preferably with the pysmurf-controller, before merging.