### PR TITLE
Update tracking.py changing the frac_pp for bands in setup_tracking_params

### DIFF
--- a/sodetlib/operations/tracking.py
+++ b/sodetlib/operations/tracking.py
@@ -395,6 +395,8 @@ def setup_tracking_params(S, cfg, bands, update_cfg=True, show_plots=False):
         'feedback_start_frac': exp['feedback_start_frac'],
         'feedback_end_frac': exp['feedback_end_frac'],
     }
+    frac_pp_all=0
+    frac_pp0=0
     for band in bands:
         sdl.pub_ocs_log(S, f"Setting up trackng params: band {band}")
         bcfg = cfg.dev.bands[band]
@@ -416,8 +418,13 @@ def setup_tracking_params(S, cfg, bands, update_cfg=True, show_plots=False):
         # Calculate trracking parameters
         S.tracking_setup(band, **tk)
         lms_meas = S.lms_freq_hz[band]
-        lms_freq = exp['nphi0'] * tk['reset_rate_khz'] * 1e3
-        frac_pp = tk['fraction_full_scale'] * lms_freq / lms_meas
+        if band==bands[0]:
+            lms_freq = exp['nphi0'] * tk['reset_rate_khz'] * 1e3
+            frac_pp = tk['fraction_full_scale'] * lms_freq / lms_meas #frac_pp for 20k for band0
+            frac_pp_all=frac_pp
+            frac_pp0=tk['fraction_full_scale']
+        else:
+            lms_freq=lms_meas*frac_pp_all/frac_pp0
 
         # Re-enables all channels and re-run tracking setup with correct params
         S.set_amplitude_scale_array(band, asa_init)


### PR DESCRIPTION
this pull request includes work done in LATR high bay cooldown, Princeton testbed, TSAT (led by @yuhanwyhan) and Cornell testbed led by @yaqiongl 

We noticed a failure mode during the LATR high bay cooldown of the setup_tracking_params.
The failure mode was then repeated in TSAT.
The core issue is setup_tracking_params shouldn't set different fraction_full_scale for different SMuRF bands, since that parameters controls the FR current magnitude and there is only one FR current flowing trough each half of the UFM. 
(There should be one fracc_pp for all bands, otherwise the previous band will have tracking issue since the tracking is done from band 0~7 in series but there is only one current flowing through all of them. Currently setup_tracking_params assigns 8 different numbers to all 8 bands )

Instead, the script should set one fixed fraction_full-scale for half UFM and set different lms_freq for each individual smurf band.

the failure mode was recorded using Mv12 in TSAT.
when running 
`tracking_res = tracking.setup_tracking_params(
        S, cfg, [0,1,2,3,4,5,6,7], show_plots=True, update_cfg=True
    )`

the script returns to a good tracking summary plot since the result shown in this plot is from the individual result of the band being tracked. 
<img width="745" alt="Screenshot 2023-07-18 at 1 51 13 PM" src="https://github.com/simonsobs/sodetlib/assets/38056285/26b4129b-2fd0-49ac-9e23-c8890c88c794">

However, when taking noise right after, the noise is high for multiple bands
<img width="761" alt="Screenshot 2023-07-18 at 1 52 04 PM" src="https://github.com/simonsobs/sodetlib/assets/38056285/87f806e5-74dd-4946-a7f7-d6219088cb38">


this failure mode remains the same even with a more accurate intial frac pp

without changing anything related to RF power but only tracking all bands again with the same frac_pp:
`for band in [0,1,2,3,4,5,6,7]:
    S.tracking_setup(band,reset_rate_khz=4,fraction_full_scale=0.368, make_plot=True, save_plot=True, show_plot=True,channel=S.which_on(band)[0:3], nsamp=2**18, lms_freq_hz=None, meas_lms_freq=True,feedback_start_frac=1/12,feedback_end_frac=1,lms_gain=1)
`
<img width="752" alt="Screenshot 2023-07-18 at 1 59 55 PM" src="https://github.com/simonsobs/sodetlib/assets/38056285/0ab0c5e6-529a-4ed3-8fca-cdfbc110b91b">

This pull request is a fix of this failure mode by calculating the frac_pp using the first band, using it for all smurf bands, and then applying different lms_freq to suit individual band

