### PR TITLE
bump so_smurf_base docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM simonsobs/so_smurf_base:v0.0.3
+FROM simonsobs/so_smurf_base:v0.0.4
 
 #################################################################
 # sodetlib Install


### PR DESCRIPTION
bump version of so_base_docker. This should fix `pysmurf.__version__` calls, which is being used by specific pysmurf functions to determine behavior.