### PR TITLE
bump docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM simonsobs/so_smurf_base:v0.0.4
+FROM simonsobs/so_smurf_base:v0.0.4-1-g74a18de
 
 #################################################################
 # sodetlib Install


### PR DESCRIPTION
Bumps docker version of so_smurf_base. This fixes bug preventing jupyter lab from running.