### PR TITLE
Adds relock_tracking_setup after setup_tracking_params finishes

### DIFF
--- a/sodetlib/operations/tracking.py
+++ b/sodetlib/operations/tracking.py
@@ -430,27 +430,22 @@ def setup_tracking_params(S, cfg, bands, update_cfg=True, show_plots=False):
         f, df, sync = S.tracking_setup(band, **tk)
         res.add_band_data(band, f, df, sync, tracking_kwargs=tk)
 
+        # Print tracking params
+        d = {
+            'frac_pp': frac_pp,
+            'lms_freq_hz': lms_freq,
+        }
+        S.log(f"Tracking params found for band {band}: {d}")
+
         # Update det config
         if update_cfg:
-            cfg.dev.update_band(band, {
-                'frac_pp':            frac_pp,
-                'lms_freq_hz':        lms_freq,
-            }, update_file=True)
+            cfg.dev.update_band(band, d, update_file=True)
 
     res.save()
-    is_interactive = plt.isinteractive()
-    try:
-        if not show_plots:
-            plt.ioff()
-        fig, ax = plot_tracking_summary(res)
-        path = sdl.make_filename(S, 'tracking_results.png', plot=True)
-        fig.savefig(path)
-        S.pub.register_file(path, 'tracking_summary', plot=True, format='png')
-        if not show_plots:
-            plt.close(fig)
-    finally:
-        if is_interactive:
-            plt.ion()
+
+    S.log("Running relock tracking setup...")
+    res = relock_tracking_setup(S, cfg, bands=bands, show_plots=show_plots)
+
     return res
 
 


### PR DESCRIPTION
As @yuhanwyhan and @yaqiongl described in #372, `setup_tracking_params` leaves you in a bad state, where the tracking is only optimized for the last band run, which can lead to high noise on AMC0 since the `lms_freqs` may not be set correctly.

I believe the best way to fix this is to run `relock_tracking_setup` after finding the tracking params for each band, which will chose a `frac_pp` based on the optimal params for each of the running bands, and will adjust `lms_freq` for each band accordingly. I have been running this manually whenever I setup_tracking_params and I think it works well, but it makes sense to just build it into the function.