### PR TITLE
Update docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx_rtd_theme==1.0.0
-sphinx-argparse==0.3.1
+sphinx_rtd_theme>=2.0.0
+sphinx-argparse>=0.4.0
 
 numpy
 scipy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-jinja2<3.1
 sphinx_rtd_theme==1.0.0
 sphinx-argparse==0.3.1
 


### PR DESCRIPTION
Prompted by Dependabot emailing me this advisory: https://github.com/simonsobs/sodetlib/security/dependabot/1

It wasn't clear to me why Jinja2 [was pinned](https://github.com/simonsobs/sodetlib/pull/228/commits/187ec4f414e0f926887c6e0758dc309f2abdd6f0). I think we should update it, but please comment if this presents problems @jlashner.

This also follows the update that @msilvafe did the other day on socs in https://github.com/simonsobs/socs/pull/618.