### PR TITLE
Change stream_g3_on kwarg make_freq_mask default to False

### DIFF
--- a/sodetlib/stream.py
+++ b/sodetlib/stream.py
@@ -127,7 +127,7 @@ def take_g3_data(S, dur, **stream_kw):
 
 
 @set_action()
-def stream_g3_on(S, make_freq_mask=True, emulator=False, tag=None,
+def stream_g3_on(S, make_freq_mask=False, emulator=False, tag=None,
                  channel_mask=None, filter_wait_time=2, make_datfile=False,
                  downsample_factor=None, downsample_mode=None,
                  filter_disable=False, stream_type=None, subtype='stream',


### PR DESCRIPTION
The `make_freq_mask` function involves a lot of EPICS calls and takes  a long time to run. This is currently causing some [issues on SAT1](https://github.com/simonsobs/daq-discussions/discussions/80), and as far as I know the resulting "freq.txt" file is not use anywhere in SO. 

This changes the stream defaults so that it does not attempt to make a frequency mask.