### PR TITLE
move bias_step init_current_mode outside of try statement

### DIFF
--- a/sodetlib/operations/bias_steps.py
+++ b/sodetlib/operations/bias_steps.py
@@ -1151,10 +1151,10 @@ def take_bias_steps(S, cfg, bgs=None, step_voltage=0.05, step_duration=0.05,
     initial_ds_factor = S.get_downsample_factor()
     initial_filter_disable = S.get_filter_disable()
     initial_dc_biases = S.get_tes_bias_bipolar_array()
+    init_current_mode = sdl.get_current_mode_array(S)
 
     try:
         dc_biases = initial_dc_biases
-        init_current_mode = sdl.get_current_mode_array(S)
         if high_current_mode:
             dc_biases = dc_biases / S.high_low_current_ratio
             step_voltage /= S.high_low_current_ratio


### PR DESCRIPTION
This moves the `init_current_mode` function outside of the try statement. This is a function to get the initial state of the current-mode, so we can recover. If this statement fails, since we haven't yet changed state, we don't need to run the `finally` block that recovers the initial state, so we don't need it inside of the `try` block.

Currently there are some instances where this function fails, and then the state-recovery fails since `init_current_mode` is not defined, such as in [this discussion](https://github.com/simonsobs/daq-discussions/discussions/92).