### PR TITLE
Change compute_psats to use last crossing of Rfrac=target_level

### DIFF
--- a/sodetlib/operations/iv.py
+++ b/sodetlib/operations/iv.py
@@ -209,7 +209,7 @@ def compute_psats(iva, psat_level=0.9):
         Array of length (nchan) with the p-sat computed for each channel (W)
     """
     # calculates P_sat as P_TES when Rfrac = psat_level
-    # if the TES is at 90% R_n more than once, just take the first crossing
+    # if the TES is at 90% R_n more than once, just take the last crossing
     for i in range(iva.nchans):
         if np.isnan(iva.R_n[i]):
             continue
@@ -218,14 +218,14 @@ def compute_psats(iva, psat_level=0.9):
         R = iva.R[i]
         R_n = iva.R_n[i]
         p_tes = iva.p_tes[i]
-        cross_idx = np.where(R/R_n > level)[0]
+        cross_idx = np.where(R/R_n < level)[0]
 
         if len(cross_idx) == 0:
             iva.p_sat[i] = np.nan
             continue
 
-        # Takes cross-index to be the first time Rfrac crosses psat_level
-        cross_idx = cross_idx[0]
+        # Takes cross-index to be the last time Rfrac crosses psat_level
+        cross_idx = cross_idx[-1]
         if cross_idx == 0:
             iva.p_sat[i] = np.nan
             continue
@@ -233,8 +233,8 @@ def compute_psats(iva, psat_level=0.9):
         iva.idxs[i, 2] = cross_idx
         try:
             iva.p_sat[i] = interp1d(
-                R[cross_idx-1:cross_idx+1]/R_n,
-                p_tes[cross_idx-1:cross_idx+1]
+                R[cross_idx:cross_idx+2]/R_n,
+                p_tes[cross_idx:cross_idx+2]
             )(level)
         except ValueError:
             iva.p_sat[i] = np.nan


### PR DESCRIPTION
I finally got around to addressing #393 . The plot below illustrates the problem, where the p_sat calculation is thrown-off by an instability in the low-R_tes portion of the IV curve. Note that target bias voltages are not affected by this.

![image](https://github.com/user-attachments/assets/44c1bb44-6563-4629-aef8-3d8bab7ff819)
Also, the full P_sat distribution looks like the below. Note all the values between 0 pW and 16 pW
![image](https://github.com/user-attachments/assets/78ea5767-0faf-434a-b5ff-b8514a1aa60a)

I then made the committed changes to the code, switching the logic from the first time R is above the target r_frac to the last time R is below the target r_frac. This fixed the psat determination in the selected detector, and it also fixed the total psat histogram to get rid of those spurious low values.

![image](https://github.com/user-attachments/assets/9e96873e-7cc1-4f90-9858-accecdd00434)
![image](https://github.com/user-attachments/assets/d8d34617-31e9-411c-8d2c-8d96e0c394f5)

Tested on a full UHF UFM in a Princeton test cryosat.