### PR TITLE
Adds data as a volume mount to run_gui

### DIFF
--- a/hammers/run_gui.sh
+++ b/hammers/run_gui.sh
@@ -16,6 +16,7 @@ docker run -it --rm  \
   -v /etc/passwrd:/etc/passerd:ro \
   -v /home/${user}/.bash_history:/home/${user}/.bash_history \
   -v /home/${user}/.Xauthority:/home/${user}/.Xauthority \
+  -v /data:/data \
   tidair/smurf-rogue:R2.8.2 \
   python3 -m pyrogue gui --server=localhost:$port
 


### PR DESCRIPTION
Mounts in the `/data` directory to the run_gui script. This was required for shawn to save state from the gui.