### PR TITLE
Adds restart_rssi script

### DIFF
--- a/scripts/restart_rssi.py
+++ b/scripts/restart_rssi.py
@@ -1,0 +1,57 @@
+import epics
+import sys
+import time
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('slot', type=int)
+parser.add_argument('--debug', action='store_true')
+
+args = parser.parse_args()
+
+slot=args.slot
+debug=args.debug
+
+# levels
+pcie_root='pcie_test0'
+pcie_top='pcie:'
+pcie_core='Core:'
+pcie_udpgrp='UdpGrp:'
+pcie_udpengine='UdpEngine[{}]:'
+pcie_rssiclient='RssiClient[{}]:'
+
+# regs
+client_remote_ip0=pcie_root+':'+pcie_top+pcie_core+pcie_udpgrp+pcie_udpengine+'ClientRemoteIp[0]'
+rssi_validcnt=pcie_root+':'+pcie_top+pcie_core+pcie_udpgrp+pcie_rssiclient+'ValidCnt'
+rssi_restartconn=pcie_root+':'+pcie_top+pcie_core+pcie_udpgrp+pcie_rssiclient+'C_RestartConn'
+
+# which slots are assigned to which udp engines
+slot2udpe={}
+nudpe=6
+ipbyeng=[epics.PV(name).get(as_string=True) for name in [client_remote_ip0.format(iudpe) for iudpe in range(nudpe)]]
+
+slots={}
+for idx,ibe in enumerate(ipbyeng):
+    s=int(ibe.split('.')[-1])-100
+    if s>0:
+        slots[s]={}
+        slots[s]['engine']=idx
+
+if slot not in slots.keys():
+    print(f'Requested slot {slot} not one of the available slots (={[int(k) for k in slots.keys()]}).  Doing nothing!')
+    sys.exit(1)
+else:
+    print(f'Restarting RSSI connection for slot {slot}.')
+    validcntpv=epics.PV(rssi_validcnt.format(slots[slot]['engine']))
+    restartconnpv=epics.PV(rssi_restartconn.format(slots[slot]['engine']))
+
+    if debug:
+        print(f'Pre-ValidCnt {validcntpv.get()}')
+    restartconnpv.put(1,wait=True)
+    if debug:
+        time.sleep(2)
+        print(f'Post-ValidCnt {validcntpv.get()}')
+        time.sleep(2)        
+        print(f'Post-ValidCnt {validcntpv.get()}')
+        time.sleep(2)        
+        print(f'Post-ValidCnt {validcntpv.get()}')


### PR DESCRIPTION
Adds a script `restart_rssi.py` based on Shawn's instructions for restarting the RSSI connection here: https://github.com/simonsobs/daq-discussions/discussions/104#discussioncomment-10812742

Merging this into sodetlib will make it easier to run this script from `/sodetlib/scripts` inside a `jackhammer util` docker.