### PR TITLE
Support usage of SMURF_CONFIG_DIR instead of OCS_CONFIG_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ venv.bak/
 
 # vscode
 .vscode
+.devcontainer/

--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -5,10 +5,17 @@ SMuRF is a complex system with many configuration parameters which vary
 depending on the cryostat, the experiment being conducted, and the network
 configuration of the smurf-server and data-acquisition nodes.
 
-These config parameters will be stored in various files in the
-``OCS_CONFIG_DIR``, where institutions will maintain and version-control the
-configuration of their systems. In the following sections we will go over what
-is contained in each file.  The hierarchy of configuration files is as follows:
+These config parameters will be stored in various files in the configuration
+directory, where institutions will maintain and version-control the
+configuration of their systems.
+
+The configuration directory may or may not be the same as the
+``OCS_CONFIG_DIR``, which contains the OCS site-config file. If it is different,
+the correct configuration path can be set separately using the
+``SMURF_CONFIG_DIR`` environment variable.
+
+In the following sections we will go over what is contained in each file.  The
+hierarchy of configuration files is as follows:
 
 sys_config
     The `sys_config` file is top-level system configuration. It contains
@@ -31,7 +38,7 @@ device config files
 
 Sys Config
 -----------
-The system configuration file is located in ``$OCS_CONFIG_DIR/sys_config.yml``
+The system configuration file is located in the ``sys_config.yml`` file
 and contains general system configuration, certain slot-specific configuration,
 and docker environment variables. See `here`_ for a template.
 
@@ -139,9 +146,10 @@ have its own entry ``SLOT[<slot>]``.
 
 Docker Environment
 ````````````````````
-Any keys in the ``docker_env`` section will be copied to ``$OCS_CONFIG_DIR/.env``
-whenever ``jackhmmer hammer`` is run, which will treat them as environment variables
-inside the docker-compose file. These are used to set the docker image tags which will be used.
+Any keys in the ``docker_env`` section will be copied to the ``.env`` file in
+the configuration directory.  Whenever ``jackhmmer hammer`` is run, which will
+treat them as environment variables inside the docker-compose file. These are
+used to set the docker image tags which will be used.
 
 Required variables are:
 

--- a/docs/scripting_guide.rst
+++ b/docs/scripting_guide.rst
@@ -161,7 +161,7 @@ simple. The script should pretty much do the following:
 2. (optional) Add command line arguments through argparse
 3. Parse args and get the SmurfControl Object
 4. Call the function
-5. Dump the updated to the device file in $OCS_CONFIG_DIR.
+5. Dump the updated to the device file.
 
 For the ``find_band`` script, this can be done as follows::
 

--- a/hammers/jackhammer
+++ b/hammers/jackhammer
@@ -31,8 +31,20 @@ def cprint(msg, style=TermColors.OKBLUE):
 
 
 # This should be the same for every smurf-srv
-cwd=os.environ['OCS_CONFIG_DIR']
-sys_config_file = os.path.join(os.environ['OCS_CONFIG_DIR'], 'sys_config.yml')
+if 'SMURF_CONFIG_DIR' in os.environ:
+    cfg_dir = os.environ['SMURF_CONFIG_DIR']
+elif 'OCS_CONFIG_DIR' in os.environ:
+    cfg_dir = os.environ['OCS_CONFIG_DIR']
+    style = TermColors.WARNING
+    cprint("SMURF_CONFIG_DIR not found in environ...", style=TermColors.WARNING)
+    cprint( f"Using OCS_CONFIG_DIR instead: {cfg_dir}...", style=TermColors.WARNING )
+else:
+    raise ValueError(
+        "SMURF_CONFIG_DIR or OCS_CONFIG_DIR must be set in the environment"
+    )
+
+cwd=cfg_dir
+sys_config_file = os.path.join(cfg_dir, 'sys_config.yml')
 
 with open(sys_config_file, 'r') as stream:
     sys_config = yaml.safe_load(stream)
@@ -273,7 +285,7 @@ def enter_pysmurf(slot, agg=False):
 
 def write_docker_env():
     docker_env = sys_config.get('docker_env')
-    with open(os.path.join(os.environ["OCS_CONFIG_DIR"], ".env"), "w") as env_file:
+    with open(os.path.join(cfg_dir, ".env"), "w") as env_file:
         for k,v in docker_env.items():
             env_file.write(f'{k}={v}\n')
 
@@ -285,13 +297,13 @@ def start_services(services, write_env=False):
             services (list or str): docker-compose services to restart
             write_env(bool):
                 If true, will write sys_config['docker-env'] to the
-                $OCS_CONFIG_DIR/.env file. This is so the most recent
+                $SMURF_CONFIG_DIR/.env file. This is so the most recent
                 environment variables can be used by standard docker-compose
                 commands.
     """
     docker_env = sys_config.get('docker_env')
 
-    # Writes docker_env to $OCS_CONFIG_DIR/.env so docker-compose still works
+    # Writes docker_env to $SMURF_CONFIG_DIR/.env so docker-compose still works
     if write_env and docker_env is not None:
         write_docker_env()
 

--- a/sodetlib/det_config.py
+++ b/sodetlib/det_config.py
@@ -348,7 +348,7 @@ def make_parser(parser=None):
     parser.add_argument_group("DetConfig Options")
     parser.add_argument('--sys-file',
                         help="Path to sys-config file. "
-                             "Defaults to ``$OCS_CONFIG_DIR/sys_config.yml``")
+                             "Defaults to ``$SMURF_CONFIG_DIR/sys_config.yml``")
     parser.add_argument('--dev-file',
                         help="Path to device-config file. "
                              "Defaults to the path specified in the sys_config.")
@@ -447,7 +447,7 @@ class DetConfig:
                 and error.
             sys_file (path, optional):
                 Path to sys config file. If None, defaults to
-                $OCS_CONFIG_DIR/sys_config.yml
+                $SMURF_CONFIG_DIR/sys_config.yml
             dev_file (path, optional):
                 Path to the Device file. If None, defaults to the device file
                 specified in the sys-config file (device_configs[slot-2]).
@@ -457,8 +457,18 @@ class DetConfig:
             uxm_file (path, optional):
                 Path to uxm file
         """
+        # This should be the same for every smurf-srv
+        if 'SMURF_CONFIG_DIR' in os.environ:
+            cfg_dir = os.environ['SMURF_CONFIG_DIR']
+        elif 'OCS_CONFIG_DIR' in os.environ:
+            cfg_dir = os.environ['OCS_CONFIG_DIR']
+        else:
+            raise ValueError(
+                "SMURF_CONFIG_DIR or OCS_CONFIG_DIR must be set in the environment"
+            )
+
         if sys_file is None:
-            self.sys_file = os.path.expandvars('$OCS_CONFIG_DIR/sys_config.yml')
+            self.sys_file = os.path.join(cfg_dir, 'sys_config.yml')
         else:
             self.sys_file = sys_file
 


### PR DESCRIPTION
This PR adds support for an environment variable $SMURF_CONFIG_DIR which will replace $OCS_CONFIG_DIR if it is specified.

The OCS_CONFIG_DIR technically needs to be the directory where the OCS default.yaml file exists, which for most lab-setups is the same as the directory where the sys_config.yml and smurf-config files live.  However for deployed servers these are different. We've been getting around by always manually specifying the ocs site-config file on deployment servers, but this will no longer be possible when the smurf-server environment is  managed more by site-computing.

Moving forward, we will want to point to the smurf-configuration directory using a separate environment variable, $SMURF_CONFIG_DIR, which defaults to OCS_CONFIG_DIR if it is not set.