### PR TITLE
Hostmanager + jackhammer compatibility

### DIFF
--- a/hammers/jackhammer
+++ b/hammers/jackhammer
@@ -76,7 +76,7 @@ def get_docker_services():
     Returns a list of docker services that are available from the docker-compose
     file in the ocs config directory.
     """
-    cmd = 'docker-compose config --services'
+    cmd = 'docker compose config --services'
     res = subprocess.run(shlex.split(cmd), cwd=cwd, stdout=subprocess.PIPE)
     return res.stdout.decode().split()
 
@@ -100,7 +100,7 @@ def util_run(cmd, args=[], name=None, rm=True, **run_kwargs):
         subprocess.run function. See the subprocess docs for allowed kwargs:
         https://docs.python.org/3/library/subprocess.html#subprocess.run
     """
-    cmd  = f'docker-compose run --entrypoint={cmd} '
+    cmd  = f'docker compose run --entrypoint={cmd} '
     if name is not None:
         cmd += f'--name={name} '
     if rm:
@@ -313,7 +313,7 @@ def start_services(services, write_env=False):
     if isinstance(services, str):
         services = [services]
 
-    cmd = 'docker-compose up -d'.split()
+    cmd = 'docker compose up -d'.split()
     cmd.extend(services)
 
     subprocess.run(cmd, cwd=cwd)
@@ -326,19 +326,21 @@ def controller_cmd(
     Brings pysmurf-controllers up or down for specified slots.
     """
     if use_hostmanager:
-        raise RuntimeError(
-            "jackhammer controller sub-command is not supported with "
-            "cfg['use_hostmanager']=True. "
+        cprint(
+            "sys_config['use_hostmanager'] is set to True, leaving controller dockers alone.",
+            style=TermColors.WARNING
         )
+        return
+
     print(f"Bringing controllers {action} for slots {slots}...")
     services = []
     for slot in slots:
         services.append(get_pysmurf_controller_docker_service(slot))
     
     if action == 'up':
-        cmd = 'docker-compose up -d'.split()
+        cmd = 'docker compose up -d'.split()
     elif action == 'down':
-        cmd = 'docker-compose stop'.split()
+        cmd = 'docker compose stop'.split()
     elif action == 'logs':
         cmd = 'docker logs -f'.split()
     else:
@@ -540,7 +542,7 @@ def setup_func(args):
 
 # Entrypoint for jackhammer logs
 def log_func(args):
-    cmd = shlex.split('docker-compose logs -f')
+    cmd = shlex.split('docker compose logs -f')
     cmd.extend(args.log_args)
     subprocess.run(cmd, cwd=cwd)
 
@@ -692,7 +694,7 @@ if __name__ == '__main__':
     ########### Jackhammer logs parser ############
     log_parser = subparsers.add_parser('logs')
     log_parser.add_argument('log_args', nargs="*", type=str,
-                            help="args passed to docker-compose logs")
+                            help="args passed to docker compose logs")
     log_parser.set_defaults(func=log_func)
 
     ########### Jackhammer util parser ############

--- a/hammers/jackhammer
+++ b/hammers/jackhammer
@@ -179,6 +179,8 @@ def kill_bad_dockers(slots, kill_monitor=False, names=[], images=[]):
     print(f"Killing bad dockers for slots {slots}")
     bad_names = names
 
+    kill_pysmurf_controllers = cfg.get('use_hostmanager', False)
+
     for slot in slots:
         # conflicting names created by jackhammer
         bad_names.append(f'smurf-streamer-s{slot}')
@@ -188,8 +190,10 @@ def kill_bad_dockers(slots, kill_monitor=False, names=[], images=[]):
         bad_names.append(f"pysmurf_s{slot}")
         bad_names.append(f"smurf_server_s{slot}")
         bad_names.append(f"pysmurf-ipython-slot{slot}")
-        bad_names.append(f'ocs-pysmurf-s{slot}')
-        bad_names.append(get_pysmurf_controller_docker_service(slot))
+
+        if kill_pysmurf_controllers:
+            bad_names.append(f'ocs-pysmurf-s{slot}')
+            bad_names.append(get_pysmurf_controller_docker_service(slot))
 
     if kill_monitor:
         bad_names.append('ocs-pysmurf-monitor')
@@ -322,6 +326,11 @@ def controller_cmd(
     """
     Brings pysmurf-controllers up or down for specified slots.
     """
+    if cfg.get('use_hostmanager', False):
+        raise RuntimeError(
+            "jackhammer controller sub-command is not supported with "
+            "cfg['use_hostmanager']=True. "
+        )
     print(f"Bringing controllers {action} for slots {slots}...")
     services = []
     for slot in slots:
@@ -406,7 +415,7 @@ def hammer_func(args):
     cprint(f"Hammering for slots {slots}", True)
 
     cprint("Killing conflicting dockers", style=TermColors.HEADER)
-    kill_bad_dockers(slots, kill_monitor=all_slots)
+    kill_bad_dockers(slots, kill_monitor=False)
 
     if all_slots:
         cprint("Restarting smurf-util", style=TermColors.HEADER)

--- a/hammers/jackhammer
+++ b/hammers/jackhammer
@@ -49,6 +49,7 @@ sys_config_file = os.path.join(cfg_dir, 'sys_config.yml')
 with open(sys_config_file, 'r') as stream:
     sys_config = yaml.safe_load(stream)
 
+use_hostmanager: bool = sys_config.get('use_hostmanager', False)
 
 def get_pysmurf_controller_docker_service(slot: int) -> str:
     """
@@ -179,8 +180,6 @@ def kill_bad_dockers(slots, kill_monitor=False, names=[], images=[]):
     print(f"Killing bad dockers for slots {slots}")
     bad_names = names
 
-    kill_pysmurf_controllers = cfg.get('use_hostmanager', False)
-
     for slot in slots:
         # conflicting names created by jackhammer
         bad_names.append(f'smurf-streamer-s{slot}')
@@ -191,7 +190,7 @@ def kill_bad_dockers(slots, kill_monitor=False, names=[], images=[]):
         bad_names.append(f"smurf_server_s{slot}")
         bad_names.append(f"pysmurf-ipython-slot{slot}")
 
-        if kill_pysmurf_controllers:
+        if not use_hostmanager:
             bad_names.append(f'ocs-pysmurf-s{slot}')
             bad_names.append(get_pysmurf_controller_docker_service(slot))
 
@@ -326,7 +325,7 @@ def controller_cmd(
     """
     Brings pysmurf-controllers up or down for specified slots.
     """
-    if cfg.get('use_hostmanager', False):
+    if use_hostmanager:
         raise RuntimeError(
             "jackhammer controller sub-command is not supported with "
             "cfg['use_hostmanager']=True. "
@@ -456,7 +455,10 @@ def hammer_func(args):
     #Brings up all smurf-streamer dockers
     cprint('Bringing up smurf dockers', style=TermColors.HEADER)
     if all_slots:
-        services = ['smurf-jupyter', 'ocs-pysmurf-monitor', 'smurf-util']
+        services = ['smurf-jupyter', 'smurf-util']
+        if not use_hostmanager:
+            services.append('ocs-pysmurf-monitor')
+
         start_sync_dockers()
     else:
         services = []
@@ -512,6 +514,13 @@ def start_sync_dockers():
     Begins suprsync docker services (by choosing all docker services that have
     "sync" in their name).
     """
+    if use_hostmanager:
+        cprint(
+            "sys_config['use_hostmanager'] is set to True, leaving sync dockers alone.",
+            style=TermColors.WARNING
+        )
+        return
+
     services = get_docker_services()
     start_services([s for s in services if 'sync' in s])
 

--- a/hammers/jackhammer
+++ b/hammers/jackhammer
@@ -50,6 +50,7 @@ with open(sys_config_file, 'r') as stream:
     sys_config = yaml.safe_load(stream)
 
 use_hostmanager: bool = sys_config.get('use_hostmanager', False)
+docker_compose_cmd: str = sys_config.get('docker_compose_command', 'docker compose')
 
 def get_pysmurf_controller_docker_service(slot: int) -> str:
     """
@@ -100,7 +101,7 @@ def util_run(cmd, args=[], name=None, rm=True, **run_kwargs):
         subprocess.run function. See the subprocess docs for allowed kwargs:
         https://docs.python.org/3/library/subprocess.html#subprocess.run
     """
-    cmd  = f'docker compose run --entrypoint={cmd} '
+    cmd  = f'{docker_compose_cmd} run --entrypoint={cmd} '
     if name is not None:
         cmd += f'--name={name} '
     if rm:
@@ -313,7 +314,7 @@ def start_services(services, write_env=False):
     if isinstance(services, str):
         services = [services]
 
-    cmd = 'docker compose up -d'.split()
+    cmd = f'{docker_compose_cmd} up -d'.split()
     cmd.extend(services)
 
     subprocess.run(cmd, cwd=cwd)
@@ -338,9 +339,9 @@ def controller_cmd(
         services.append(get_pysmurf_controller_docker_service(slot))
     
     if action == 'up':
-        cmd = 'docker compose up -d'.split()
+        cmd = f'{docker_compose_cmd} up -d'.split()
     elif action == 'down':
-        cmd = 'docker compose stop'.split()
+        cmd = f'{docker_compose_cmd} stop'.split()
     elif action == 'logs':
         cmd = 'docker logs -f'.split()
     else:
@@ -542,7 +543,7 @@ def setup_func(args):
 
 # Entrypoint for jackhammer logs
 def log_func(args):
-    cmd = shlex.split('docker compose logs -f')
+    cmd = shlex.split(f'{docker_compose_cmd} logs -f')
     cmd.extend(args.log_args)
     subprocess.run(cmd, cwd=cwd)
 


### PR DESCRIPTION
In the near future, we want to get hostmanager operating on smurf-servers to automatically start ocs agents.

Once this is the case, we will not want to touch ocs dockers using jackhammer... it should all be managed by the hostmanager.

With this PR, if  `sys_config["use_hostmanager"]` is set to True, it will exclude ocs dockers from any hammer operations. 

When setting this up, we will need to move ocs-related docker services to an independent docker-compose file to keep host-manager from interacting with smurf-streamer dockers, as is done here: https://github.com/simonsobs/ocs-deployment-configs/pull/332.