### PR TITLE
remove docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM simonsobs/so_smurf_base:v0.0.4-1-g74a18de
-
-#################################################################
-# sodetlib Install
-#################################################################
-COPY . /sodetlib
-WORKDIR /sodetlib
-RUN pip3 install -e .
-RUN pip3 install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,0 @@
-version: '3.7'
-services:
-    sodetlib:
-        image: sodetlib
-        build: .


### PR DESCRIPTION
I'm proposing we remove the `sodetlib` docker container. As far as I can tell it is only used to build the `ocs-pysmurf-agent` ([here](https://github.com/simonsobs/socs/blob/main/docker/pysmurf_controller/Dockerfile)), and we could simply install `sodetlib` and specify a release tag there. The only other reference I have found to this image are in `docker-compose.yaml` files committed to the `ocs-site-configs` repo for some institutions. In the SAT/LAT configs it has been replaced by `ocs-pysmurf-agent`. We should then also remove the `SODETLIB_TAG` that remains in those configs but is unused.

This would simplify the release process by removing one layer of docker inheritance, but I appreciate that I may have overlooked other uses of this image (although I did not find any in the `simonsobs` organisation), so please let me know if you think this may be the case.

An accompanying PR will be necessary in `socs` to install `sodetlib` in the corresponding `Dockerfile`.