### PR TITLE
Remove logging of every bias step.

### DIFF
--- a/sodetlib/operations/iv.py
+++ b/sodetlib/operations/iv.py
@@ -646,7 +646,7 @@ def take_iv(S, cfg, **kwargs):
         S.log(f"Starting TES Bias Ramp on bg {bgs}")
         for i, bias in enumerate(ivcfg.biases):
             sdl.stop_point(S)
-            S.log(f"Setting bias to {bias:4.3f}")
+            S.log(f"Setting bias to {bias:4.3f}", S.LOG_INFO)
             _bias_arr[bgs] = bias
             S.set_tes_bias_bipolar_array(_bias_arr)
             start_times[bgs, i] = time.time()


### PR DESCRIPTION
During my SMuRF tsar shift I noticed that the logs in the pysmurf controllers were often hard to read due to their volume and the mix of `sodetlib` / `pysmurf` / other origins that were sometimes conflicting. I think there might be some improvement possible on the `pysmurf` side, so I'll create an issue there.

This was one particularly egregious example.