### PR TITLE
Force feedback to be enabled on active bands during setup/relock

### DIFF
--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -363,6 +363,10 @@ def uxm_relock(
     summary['timestamps'].append(('tracking_setup', time.time()))
     sdl.set_session_data(S, 'timestamps', summary['timestamps'])
 
+    # Ensure feedback is enabled
+    for b in bands:
+        S.set_feedback_enable(b, 1)
+
     tr = relock_tracking_setup(
         S, cfg, bands, show_plots=show_plots,
         reset_rate_khz=reset_rate_khz, nphi0=nphi0

--- a/sodetlib/operations/uxm_setup.py
+++ b/sodetlib/operations/uxm_setup.py
@@ -737,6 +737,11 @@ def uxm_setup(S, cfg, bands=None, show_plots=True, update_cfg=True,
     #############################################################
     summary['timestamps'].append(('setup_tracking', time.time()))
     sdl.set_session_data(S, 'timestamps', summary['timestamps'])
+
+    # Ensure feedback is enabled
+    for b in bands:
+        S.set_feedback_enable(b, 1)
+
     tracking_res = tracking.setup_tracking_params(
         S, cfg, bands, show_plots=show_plots, update_cfg=update_cfg
     )


### PR DESCRIPTION
Responds to issue where feedback spontaneously disables during hammer. Forces feedback to be enabled before tracking during `uxm_setup` and `uxm_relock`