### PR TITLE
Drop extra dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-jupyterlab
 tqdm
 setuptools >= 56.2.0
-ipykernel>=5.5.4
+ipython
 PyYAML
 numpy
 scipy


### PR DESCRIPTION
This PR drops both several unused dependencies from the `requirements.txt` file. This is half of #466. 

Comments on specific packages are in commits relevant to the package removal, but to reiterate:
* `jedi` - A static analysis tool that integrates to IDEs/language servers.
* `seaborn` - Plotting package. Not imported anywhere in sodetlib.
* `pyfftw` - This might have once been used in sodetlib, but it looks like that functionality moved to [sotodlib](https://github.com/simonsobs/sotodlib/blob/master/sotodlib/tod_ops/fft_ops.py).
* `jupyterlab` + `ipykernel` - Used for interactive `smurf-jupyter` sessions. These are both also pulled in via installation of the main `jupyter` package in the [pysmurf base docker image](https://github.com/simonsobs/smurf_dockers/blob/main/pysmurf/requirements.txt).

I added `ipython` because [`scripts/start_pysmurf_ipython.py`](https://github.com/simonsobs/sodetlib/blob/b5b80c55ea6ec9276d1ede269c9cb66781f0de56/scripts/start_pysmurf_ipython.py#L1) imports it -- and I suspect it was available to import because of the `ipykernel` package pulling it in.

This has not been tested at all, as I don't have a good testing environment.