### PR TITLE
Add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,16 @@ dependencies = [
     "tqdm",
 ]
 
+[project.optional-dependencies]
+scripts = [
+    "ipython",
+    "traitlets",
+]
+dev = [
+    "pytest",
+    "setuptools-scm",
+]
+
 [project.scripts]
 jackhammer = "sodetlib.hammers.jackhammer:main"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 tqdm
-ipython
-setuptools-scm
 PyYAML
 numpy
 scipy
@@ -15,3 +13,11 @@ sotodlib @ git+https://github.com/simonsobs/sotodlib.git@5d613d5915b1716c401abec
 # pysmurf can be installed from PyPI once [3] is merged and a new release is made
 # [3] - https://github.com/slaclab/pysmurf/pull/824
 pysmurf @ git+https://github.com/slaclab/pysmurf.git@main
+
+# scripts
+ipython
+traitlets
+
+# dev
+pytest
+setuptools-scm

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ pandas
 # [1] - https://github.com/simonsobs/smurf_dockers/pull/6
 # [2] - https://github.com/simonsobs/socs/blob/main/docker/pysmurf_controller/Dockerfile
 sotodlib @ git+https://github.com/simonsobs/sotodlib.git@5d613d5915b1716c401abecb5446088bce5fc1a4
+# pysmurf can be installed from PyPI once [3] is merged and a new release is made
+# [3] - https://github.com/slaclab/pysmurf/pull/824
+pysmurf @ git+https://github.com/slaclab/pysmurf.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pandas
 # i.e. when [1] is merged and propagated to [2].
 # [1] - https://github.com/simonsobs/smurf_dockers/pull/6
 # [2] - https://github.com/simonsobs/socs/blob/main/docker/pysmurf_controller/Dockerfile
-sotodlib @ git+https://github.com/simonsobs/sotodlib.git@f3f9a97
+sotodlib @ git+https://github.com/simonsobs/sotodlib.git@5d613d5915b1716c401abecb5446088bce5fc1a4


### PR DESCRIPTION
This PR adds missing dependencies to our `pyproject.toml` and `requirements.txt` files. This is related to the packaging work I've been doing in #493, #494, and #497.

The main focus here is `sotodlib` and `pysmurf`. These are currently defined in `socs`, and get installed for use by the pysmurf-controller agent there. However, these packages aren't imported anywhere in `socs`, they're really dependencies of `sodetlib` and so should be defined as dependencies here, not in `socs`.

`traitlets` and `pytest` were also missing, so I added those while I was reviewing imports.

EDIT: I left off `pyepics` because of its impending removal in #485.