### PR TITLE
Install pysmurf from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
+    "pysmurf-slac",
     "PyYAML",
     "scipy",
     "tqdm",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,7 @@ pandas
 # [1] - https://github.com/simonsobs/smurf_dockers/pull/6
 # [2] - https://github.com/simonsobs/socs/blob/main/docker/pysmurf_controller/Dockerfile
 sotodlib @ git+https://github.com/simonsobs/sotodlib.git@5d613d5915b1716c401abecb5446088bce5fc1a4
-# pysmurf can be installed from PyPI once [3] is merged and a new release is made
-# [3] - https://github.com/slaclab/pysmurf/pull/824
-pysmurf @ git+https://github.com/slaclab/pysmurf.git@main
+pysmurf-slac
 
 # scripts
 ipython


### PR DESCRIPTION
Now that pysmurf is [published to PyPI](https://pypi.org/project/pysmurf-slac/), we can install the latest release from there instead of needing to install from VCS.

This doesn't currently change anything downstream in the pysmurf-controller Docker image. The `pysmurf-slac` package gets installed (version 9.0.1), but the version 8.1.0 that is cloned and [inserted into the `PYTHONPATH`](https://github.com/simonsobs/smurf_dockers/blob/3bb520cca801d46981af063309ab1d5f94503b83/pysmurf/Dockerfile#L37) takes precedence and is what ends up being used. This'll be true until https://github.com/simonsobs/smurf_dockers/issues/7 is resolved.

That said, happy to wait on this until the Rogue 6 update happens. Whatever is easiest for you @tristpinsm.