### PR TITLE
fix(jackhammer): Sleep briefly after carrier ping response

### DIFF
--- a/sodetlib/hammers/jackhammer.py
+++ b/sodetlib/hammers/jackhammer.py
@@ -450,6 +450,8 @@ def hammer_func(args):
             # ip = f'10.0.{sys_config["crate_id"]}.{slot + 100}'
             ip = get_slot_ip(slot)
             subprocess.run(['ping_carrier', ip])
+        print("Sleeping for 1s")
+        time.sleep(1)
     else:
         print("Skipping reboot process")
 


### PR DESCRIPTION
I found that occasionally `jackhammer` fails with an error like 
```
2026-04-29 18:51:42.213	
Error in setup_server script! Exited with return code 1
	
		2026-04-29 18:51:42.213	
Reading FW Git Hash via IPMI...                   An ERROR was found. Check shelf manager & card state! Aborting...
	
		2026-04-29 18:51:42.213	
Looking for mcs file...                           Mcs file found: MicrowaveMuxBpEthGen2-0x02040000-20260414104316-ruckman-33885cfb.mcs
```

A bit of debugging on `smurf-so7-lat` revealed that this doesn't happen on a soft hammer (restarting the streamer without power cycling the slot), and that adding a delay between power cycling and querying the crate ID seems to resolve the issue.

Probably needs a bit more testing to confirm this is the mechanism for the failure.