### PR TITLE
Include setup_fixed_tones in setup_tune

### DIFF
--- a/sodetlib/operations/uxm_setup.py
+++ b/sodetlib/operations/uxm_setup.py
@@ -398,7 +398,8 @@ def estimate_uc_dc_atten(S, cfg, band, update_cfg=True, tone_power=None):
 @sdl.set_action()
 def setup_tune(S, cfg, bands, show_plots=False, update_cfg=True):
     """
-    Find freq, setup notches, and serial gradient descent and eta scan
+    Find freq, setup notches, and serial gradient descent and eta scan.
+    Also sets up fixed tones, but does not turn them on.
 
     The following parameters can be modified in the device cfg:
 
@@ -446,6 +447,8 @@ def setup_tune(S, cfg, bands, show_plots=False, update_cfg=True):
 
     if update_cfg:
         cfg.dev.update_experiment({'tunefile': S.tune_file}, update_file=True)
+
+    setup_fixed_tones(S, cfg, bands=bands, update_cfg=update_cfg)
 
     return True, summary
 


### PR DESCRIPTION
Addresses issue #506 

If `stream_g3_on` always tries to turn on fixed tones, then we need to be sure there is always a list of viable fixed tones for any tunefile. This PR does this by including `setup_fixed_tones` as the last step of `setup_tune`.