### PR TITLE
Wrap setup_amps in try during relock for two attempts

### DIFF
--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -262,7 +262,7 @@ def plot_channel_resonance(S, cfg, band, chan):
 def uxm_relock(
     S, cfg, bands=None, show_plots=False,
     setup_notches=False, new_master_assignment=False, reset_rate_khz=None,
-    nphi0=None, skip_setup_amps=False):
+    nphi0=None, skip_setup_amps=False, max_setup_amps_attempts=3):
     """
     Relocks resonators by running the following steps:
 
@@ -294,6 +294,8 @@ def uxm_relock(
         If True will show plots
     skip_setup_amps : bool
         If True will skip amplifier setup.
+    max_setup_amps_attempts : int
+        Maximum number of attempts at setting up amplifiers before returning error
 
     Returns
     --------
@@ -335,15 +337,13 @@ def uxm_relock(
     if not skip_setup_amps:
         summary['timestamps'].append(('setup_amps', time.time()))
         sdl.set_session_data(S, 'timestamps', summary['timestamps'])
-
-        # May take two tries
-        try:
-            success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
-        except:
+        for i in range(max_setup_amps_attempts):
             try:
                 success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
+                break
             except:
-                return False
+                success = False
+                S.log('Failed uxm_setup.setup_amps on %i/%i attempt' % (i, max_setup_amps_attempts))
 
         if not success:
             return False, summary

--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -335,7 +335,15 @@ def uxm_relock(
     if not skip_setup_amps:
         summary['timestamps'].append(('setup_amps', time.time()))
         sdl.set_session_data(S, 'timestamps', summary['timestamps'])
-        success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
+
+        # May take two tries
+        try:
+            success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
+        except:
+            try:
+                success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
+            except:
+                return False
 
         if not success:
             return False, summary

--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -262,7 +262,7 @@ def plot_channel_resonance(S, cfg, band, chan):
 def uxm_relock(
     S, cfg, bands=None, show_plots=False,
     setup_notches=False, new_master_assignment=False, reset_rate_khz=None,
-    nphi0=None, skip_setup_amps=False, max_setup_amps_attempts=3):
+    nphi0=None, skip_setup_amps=False):
     """
     Relocks resonators by running the following steps:
 
@@ -294,8 +294,6 @@ def uxm_relock(
         If True will show plots
     skip_setup_amps : bool
         If True will skip amplifier setup.
-    max_setup_amps_attempts : int
-        Maximum number of attempts at setting up amplifiers before returning error
 
     Returns
     --------
@@ -337,14 +335,7 @@ def uxm_relock(
     if not skip_setup_amps:
         summary['timestamps'].append(('setup_amps', time.time()))
         sdl.set_session_data(S, 'timestamps', summary['timestamps'])
-        for i in range(max_setup_amps_attempts):
-            try:
-                success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
-                break
-            except:
-                success = False
-                S.log('Failed uxm_setup.setup_amps on %i/%i attempt' % (i, max_setup_amps_attempts))
-                time.sleep(0.1)
+        success, summary['amps'] = uxm_setup.setup_amps(S, cfg)
 
         if not success:
             return False, summary

--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -344,6 +344,7 @@ def uxm_relock(
             except:
                 success = False
                 S.log('Failed uxm_setup.setup_amps on %i/%i attempt' % (i, max_setup_amps_attempts))
+                time.sleep(0.1)
 
         if not success:
             return False, summary

--- a/sodetlib/operations/uxm_setup.py
+++ b/sodetlib/operations/uxm_setup.py
@@ -145,7 +145,7 @@ def find_drain_voltage(S, target_Id, amp_name, vd_min=0.1, vd_max=0.95,
 
 
 @sdl.set_action()
-def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True):
+def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True, max_attempts=3):
     """
     Initial setup for 50k and hemt amplifiers. For C04/C05 cryocards, will first
     check if the drain voltages are set. Then checks if drain
@@ -175,6 +175,9 @@ def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True):
         If true, will update the device cfg and save the file.
     enable_300K_LNA:
         If true, will turn on the 300K LNAs.
+    max_attempts : int
+        Maximum number of attempts at reading amplifier biases,
+        which sometimes fails
     """
     sdl.pub_ocs_log(S, "Starting setup_amps")
 
@@ -214,7 +217,20 @@ def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True):
         if cc_rev == 'c04':
             summary[f'{amp}_drain_volt'] = None
 
-    amp_biases = S.get_amplifier_biases()
+    attempts = 0
+    read_biases_success = False
+    while not read_biases_success:
+        attempts += 1
+        try:
+            amp_biases = S.get_amplifier_biases()
+            read_biases_success = True
+        except Exception as e:
+            S.log('Failed S.get_amplifier_biases on attempt %i/%i' % (attempts, max_attempts))
+            if attempts < max_attempts:
+                # May benefit from short pause
+                time.sleep(0.1)
+            else:
+                raise e
 
     # For C04, first check drain voltages
     if cc_rev == 'c04':

--- a/sodetlib/operations/uxm_setup.py
+++ b/sodetlib/operations/uxm_setup.py
@@ -223,6 +223,11 @@ def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True, max_attempts=3):
         attempts += 1
         try:
             amp_biases = S.get_amplifier_biases()
+
+            # Attempt to read Vds
+            for amp in amp_list:
+                _ = amp_biases[f"{amp}_drain_volt"]
+
             read_biases_success = True
         except Exception as e:
             S.log('Failed S.get_amplifier_biases on attempt %i/%i' % (attempts, max_attempts))

--- a/sodetlib/operations/uxm_setup.py
+++ b/sodetlib/operations/uxm_setup.py
@@ -226,7 +226,7 @@ def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True, max_attempts=3):
 
             # Attempt to read Vds
             for amp in amp_list:
-                _ = amp_biases[f"{amp}_drain_volt"]
+                _ = amp_biases[f"{amp}_drain_current"]
 
             read_biases_success = True
         except Exception as e:

--- a/sodetlib/operations/uxm_setup.py
+++ b/sodetlib/operations/uxm_setup.py
@@ -224,7 +224,7 @@ def setup_amps(S, cfg, update_cfg=True, enable_300K_LNA=True, max_attempts=3):
         try:
             amp_biases = S.get_amplifier_biases()
 
-            # Attempt to read Vds
+            # Attempt to read Ids
             for amp in amp_list:
                 _ = amp_biases[f"{amp}_drain_current"]
 


### PR DESCRIPTION
Semi-frequently after a hammer `setup_amps` fails on `uxm_relock`, usually due to a key error for the name of one of the amplifiers. It's pretty much always fixed by running `uxm_relock` again, but ROCs don't know to do this and smurf-tsars can be slow to respond.

This is a very simple solution of wrapping `setup_amps` in a `try`. If it fails, it tries again. If the second attempt fails, then it errors out.