### PR TITLE
Change relock_tracking to setup_tracking in uxm_relock

### DIFF
--- a/sodetlib/operations/uxm_relock.py
+++ b/sodetlib/operations/uxm_relock.py
@@ -1,7 +1,7 @@
 import time
 import numpy as np
 import sodetlib as sdl
-from sodetlib.operations.tracking import relock_tracking_setup
+from sodetlib.operations.tracking import setup_tracking_params
 from sodetlib.operations import uxm_setup, bias_steps
 
 import matplotlib.pyplot as plt
@@ -367,9 +367,14 @@ def uxm_relock(
     for b in bands:
         S.set_feedback_enable(b, 1)
 
-    tr = relock_tracking_setup(
-        S, cfg, bands, show_plots=show_plots,
-        reset_rate_khz=reset_rate_khz, nphi0=nphi0
+    # Possibly override cfg values to pass to tracking setup
+    if reset_rate_khz is not None:
+        cfg.dev.exp['flux_ramp_rate_khz'] = reset_rate_khz
+    if nphi0 is not None:
+        cfg.dev.exp['nphi0'] = nphi0
+
+    tr = setup_tracking_params(
+        S, cfg, bands=bands, show_plots=show_plots
     )
     summary['tracking_setup_results'] = tr
 


### PR DESCRIPTION
Lately, we've been made aware of the fact that tracking can degrade over time. Right now, we have an alert which ROCs flag to SMuRF Tsars, who then run `setup_tracking` to fix the issue. Best case scenario, it can be a bit difficult for SMuRF Tsars to take time to do this, and to find time in the platform's schedule. Worst case scenario, we miss this and have degraded performance without realizing it.

Since we run `uxm_relock` each day, running `setup_tracking` each time should fix the issue. We lose a few minutes from added execution time, but we save the overhead of identifying and fixing the degraded tracking.

It's not entirely clear why this is happening in the first place; we don't expect drifts to the FR put out by the RTM. But if this PR fixes the issue, it may not warrant further investigation given the bandwidth constraints of the relevant parties.