### PR TITLE
Pin pysmurf to latest Rogue 4 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
-    "pysmurf-slac",
+    "pysmurf-slac==10.3.4",
     "PyYAML",
     "scipy",
     "tqdm",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas
 # [1] - https://github.com/simonsobs/smurf_dockers/pull/6
 # [2] - https://github.com/simonsobs/socs/blob/main/docker/pysmurf_controller/Dockerfile
 sotodlib @ git+https://github.com/simonsobs/sotodlib.git@5d613d5915b1716c401abecb5446088bce5fc1a4
-pysmurf-slac
+pysmurf-slac==10.3.4
 
 # scripts
 ipython


### PR DESCRIPTION
Recent pysmurf versions [require Python 3.10](https://github.com/slaclab/pysmurf/pull/1010). We should pin to the latest Rogue 4 version (which supports Python 3.8 still) until https://github.com/simonsobs/sodetlib/pull/485 is complete.

This was mostly motivated by the `socs` image build for the pysmurf-controller, which ran into issues recently. See https://github.com/simonsobs/socs/pull/1077 for some more detail/context.