### PR TITLE
Expose jackhammer function to programmatic use

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,6 +9,7 @@ on:
       - '**.rst'
       - '**.md'
       - '.readthedocs.yaml'
+  pull_request:
 
 jobs:
   wheel:
@@ -46,3 +47,8 @@ jobs:
       working-directory: ./tests  # avoid direct usage of ./sodetlib/
       run: |
         python3 -c 'import sodetlib'
+
+    - name: run tests
+      working-directory: ./tests
+      run: |
+        python3 -m pytest test_jackhammer.py -v

--- a/sodetlib/hammers/jackhammer.py
+++ b/sodetlib/hammers/jackhammer.py
@@ -108,20 +108,30 @@ def util_run(cmd, args=[], name=None, rm=True, **run_kwargs):
     return subprocess.run(shlex.split(cmd), cwd=cwd, **run_kwargs)
 
 
-def check_epics_connection(epics_server, retry=False):
+def check_epics_connection(epics_server, retry=False, timeout=180):
     """
-        Checks if we can connect to a specific epics server. 
+        Checks if we can connect to a specific epics server.
 
         Args:
-            epics_server (string): 
+            epics_server (string):
                 epics server to connect to
             retry (bool):
-                If true, will continuously check until a connection has been 
+                If true, will continuously check until a connection has been
                 established.
+            timeout (int):
+                Maximum seconds to wait when retry is True. Raises
+                TimeoutError if exceeded.
     """
     if retry:
         print(f"Waiting for epics connection to {epics_server}", end='', flush=True)
+        start = time.time()
         while True:
+            if time.time() - start > timeout:
+                print()
+                raise TimeoutError(
+                    f"Timed out after {timeout}s waiting for EPICS "
+                    f"connection to {epics_server}"
+                )
             x = util_run(
                 'caget', args=[f'{epics_server}:AMCc:enable'],
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT
@@ -387,8 +397,13 @@ def pysmurf_func(args):
 
 
 def hammer(slots=None, no_reboot=False, no_dump=False, skip_setup=False,
-           dump_rogue=False):
+           dump_rogue=False, ping_timeout=120, epics_timeout=180,
+           setup_timeout=300):
     """Core hammer sequence to reset and reconfigure SMuRF slots.
+
+    Individual slot failures (ping timeout, EPICS timeout, setup error)
+    are caught and recorded so that the remaining slots can still
+    complete successfully.
 
     Args
     ------
@@ -402,6 +417,17 @@ def hammer(slots=None, no_reboot=False, no_dump=False, skip_setup=False,
         If True, skip pysmurf setup after reboot.
     dump_rogue : bool
         If True, dump the rogue tree before hammering.
+    ping_timeout : int
+        Seconds to wait for each carrier to respond after reboot.
+    epics_timeout : int
+        Seconds to wait for each slot's EPICS connection.
+    setup_timeout : int
+        Seconds to wait for each slot's pysmurf setup thread.
+
+    Returns
+    -------
+    dict
+        ``{'succeeded': [slot, ...], 'failed': {slot: reason, ...}}``
     """
     if not slots:
         slots = sys_config['slot_order']
@@ -414,8 +440,8 @@ def hammer(slots=None, no_reboot=False, no_dump=False, skip_setup=False,
 
     reboot = not no_reboot
     all_slots = len(slots) == len(sys_config['slot_order'])
+    failed_slots = {}
 
-    # dump docker logs for debugging.
     if not no_dump:
         dump_docker_logs(slots, dump_rogue_tree=dump_rogue)
 
@@ -454,9 +480,23 @@ def hammer(slots=None, no_reboot=False, no_dump=False, skip_setup=False,
         print("Waiting for carriers to come back online (this takes a bit)")
         for slot in slots:
             ip = get_slot_ip(slot)
-            subprocess.run(['ping_carrier', ip])
+            try:
+                subprocess.run(['ping_carrier', ip], timeout=ping_timeout)
+            except subprocess.TimeoutExpired:
+                msg = f"Carrier ping timed out after {ping_timeout}s"
+                cprint(f"Slot {slot}: {msg}", style=TermColors.FAIL)
+                failed_slots[slot] = msg
+            except Exception as e:
+                msg = f"Carrier ping failed: {e}"
+                cprint(f"Slot {slot}: {msg}", style=TermColors.FAIL)
+                failed_slots[slot] = msg
     else:
         print("Skipping reboot process")
+
+    active_slots = [s for s in slots if s not in failed_slots]
+    if not active_slots:
+        cprint("All slots failed during reboot", style=TermColors.FAIL)
+        return {'succeeded': [], 'failed': failed_slots}
 
     cprint('Bringing up smurf dockers', style=TermColors.HEADER)
     if all_slots:
@@ -468,22 +508,47 @@ def hammer(slots=None, no_reboot=False, no_dump=False, skip_setup=False,
     else:
         services = []
 
-    for slot in slots:
+    for slot in active_slots:
         services.append(f'smurf-streamer-s{slot}')
 
     start_services(services)
     start_sync_dockers()
-    controller_cmd(slots, 'up')
+    controller_cmd(active_slots, 'up')
 
     print("Waiting for server dockers to connect. This might take a few minutes...")
-    for slot in slots:
+    # Iterate over a copy — we remove failed slots from active_slots in the loop body
+    for slot in active_slots[:]:
         epics_server = f'smurf_server_s{slot}'
-        check_epics_connection(epics_server, retry=True)
+        try:
+            check_epics_connection(epics_server, retry=True,
+                                   timeout=epics_timeout)
+        except TimeoutError:
+            msg = f"Server ping timed out after {epics_timeout}s"
+            cprint(f"Slot {slot}: {msg}", style=TermColors.FAIL)
+            failed_slots[slot] = str(msg)
+            active_slots.remove(slot)
+        except Exception as e:
+            msg = f"EPICS connection failed: {e}"
+            cprint(f"Slot {slot}: {msg}", style=TermColors.FAIL)
+            failed_slots[slot] = msg
+            active_slots.remove(slot)
 
-    if reboot and not skip_setup:
+    if reboot and not skip_setup and active_slots:
         cprint("Configuring pysmurf", style=TermColors.HEADER)
-        setup_smurfs(slots)
-        print("Finished configuring pysmurf!")
+        setup_errors = setup_smurfs(active_slots, timeout=setup_timeout)
+        for slot, error in setup_errors.items():
+            cprint(f"Slot {slot}: {error}", style=TermColors.FAIL)
+            failed_slots[slot] = error
+        active_slots = [s for s in active_slots if s not in setup_errors]
+        if active_slots:
+            print("Finished configuring pysmurf!")
+
+    if failed_slots:
+        cprint(f"Failed slots: {failed_slots}", style=TermColors.FAIL)
+    if active_slots:
+        cprint(f"Succeeded slots: {active_slots}", True)
+
+    return {'succeeded': active_slots, 'failed': failed_slots}
 
 
 # Entrypoint for jackhammer hammer
@@ -511,29 +576,55 @@ def hammer_func(args):
     cprint(f"Entering pysmurf slot {slots[0]}", style=TermColors.HEADER)
     enter_pysmurf(slots[0], agg=args.agg)
 
-def setup_smurfs(slots):
+def setup_smurfs(slots, timeout=300):
     """
-    Runs S.setup on one or more slots in parallel
+    Runs S.setup on one or more slots in parallel.
 
     Args
     -----
     slots : list
         List of slots to run on
+    timeout : int
+        Maximum seconds to wait for each slot's setup thread.
+
+    Returns
+    -------
+    dict
+        Mapping of ``{slot: error_message}`` for slots that failed.
+        Empty dict means all slots succeeded.
     """
-    threads = []
+    errors = {}
+    lock = threading.Lock()
+
+    def _run_setup(slot):
+        # Catch all exceptions so a thread crash (e.g. missing docker binary)
+        # gets recorded instead of silently lost.
+        try:
+            res = util_run(
+                'python3',
+                args=f'/sodetlib/scripts/setup_pysmurf.py -N {slot}'.split(),
+            )
+            if res.returncode != 0:
+                with lock:
+                    errors[slot] = "Pysmurf setup returned a non-zero exit code."
+        except Exception as e:
+            with lock:
+                errors[slot] = f"Pysmurf setup raised: {e}"
+
+    threads = {}
     for s in slots:
         print(f"Configuring pysmurf on slot {s}...")
-        kw = {
-            'args': ('python3',),
-            'kwargs': {'args': f'/sodetlib/scripts/setup_pysmurf.py -N {s}'.split()}
-
-        }
-        th = threading.Thread(target=util_run, **kw )
+        th = threading.Thread(target=_run_setup, args=(s,))
         th.start()
-        threads.append(th)
+        threads[s] = th
 
-    for th in threads:
-        th.join()
+    for s, th in threads.items():
+        th.join(timeout=timeout)
+        if th.is_alive():
+            with lock:
+                errors.setdefault(s, f"Pysmurf setup timed out after {timeout}s")
+
+    return errors
 
 def start_sync_dockers():
     """

--- a/sodetlib/hammers/jackhammer.py
+++ b/sodetlib/hammers/jackhammer.py
@@ -386,31 +386,38 @@ def pysmurf_func(args):
     enter_pysmurf(slot, agg=args.agg)
 
 
-# Entrypoint for jackhammer hammer
-def hammer_func(args):
-    # here we go....
-    if not args.slots:
+def hammer(slots=None, no_reboot=False, no_dump=False, skip_setup=False,
+           dump_rogue=False):
+    """Core hammer sequence to reset and reconfigure SMuRF slots.
+
+    Args
+    ------
+    slots : list of int, optional
+        Slot numbers to hammer. Defaults to all slots in sys_config.
+    no_reboot : bool
+        If True, perform a soft reset without rebooting the carriers.
+    no_dump : bool
+        If True, skip dumping docker logs before hammering.
+    skip_setup : bool
+        If True, skip pysmurf setup after reboot.
+    dump_rogue : bool
+        If True, dump the rogue tree before hammering.
+    """
+    if not slots:
         slots = sys_config['slot_order']
     else:
-        slots = args.slots
         for s in slots:
             if s not in sys_config['slot_order']:
                 raise ValueError(
                     f"Slot {s} is not valid for this system! Can only use "
                     f"slots in: {sys_config['slot_order']}")
 
-    reboot = not (args.no_reboot)
+    reboot = not no_reboot
     all_slots = len(slots) == len(sys_config['slot_order'])
 
-    reboot_str = "hard" if reboot else "soft"
-    cmd = input(f"You are {reboot_str}-resetting slots {slots}. "
-                "Are you sure (y/n)? ")
-    if cmd.lower() not in ["y", "yes"]:
-        return
-
     # dump docker logs for debugging.
-    if not args.no_dump:
-        dump_docker_logs(slots)
+    if not no_dump:
+        dump_docker_logs(slots, dump_rogue_tree=dump_rogue)
 
     cprint(f"Hammering for slots {slots}", True)
 
@@ -419,22 +426,21 @@ def hammer_func(args):
 
     if all_slots:
         cprint("Restarting smurf-util", style=TermColors.HEADER)
-        # Restarts smurf-util to clean up any running processes
         subprocess.run('docker stop smurf-util'.split(), cwd=cwd)
         subprocess.run('docker rm smurf-util'.split(), cwd=cwd)
         start_services('smurf-util', write_env=True)
 
-        # Sets fan levels on crate
         cprint("Setting fan levels", style=TermColors.HEADER)
         setup_fans()
 
     if reboot:
         cprint(f"Rebooting slots: {slots}", style=TermColors.HEADER)
-        deactivate_commands = []
-        activate_commands = []
-        for slot in slots:
-            deactivate_commands.append(f'clia deactivate board {slot}')
-            activate_commands.append(f'clia activate board {slot}')
+        deactivate_commands = [
+            f'clia deactivate board {slot}' for slot in slots
+        ]
+        activate_commands = [
+            f'clia activate board {slot}' for slot in slots
+        ]
 
         print(f"Deactivating carriers: {slots}")
         run_on_shelf_manager('; '.join(deactivate_commands))
@@ -447,13 +453,11 @@ def hammer_func(args):
 
         print("Waiting for carriers to come back online (this takes a bit)")
         for slot in slots:
-            # ip = f'10.0.{sys_config["crate_id"]}.{slot + 100}'
             ip = get_slot_ip(slot)
             subprocess.run(['ping_carrier', ip])
     else:
         print("Skipping reboot process")
 
-    #Brings up all smurf-streamer dockers
     cprint('Bringing up smurf dockers', style=TermColors.HEADER)
     if all_slots:
         services = ['smurf-jupyter', 'smurf-util']
@@ -471,18 +475,39 @@ def hammer_func(args):
     start_sync_dockers()
     controller_cmd(slots, 'up')
 
-    # Waits for streamer-dockers to start
     print("Waiting for server dockers to connect. This might take a few minutes...")
     for slot in slots:
         epics_server = f'smurf_server_s{slot}'
         check_epics_connection(epics_server, retry=True)
 
-    if reboot and not args.skip_setup:
+    if reboot and not skip_setup:
         cprint("Configuring pysmurf", style=TermColors.HEADER)
         setup_smurfs(slots)
         print("Finished configuring pysmurf!")
 
-    # Enters into an ipython notebook for the first specified slot   
+
+# Entrypoint for jackhammer hammer
+def hammer_func(args):
+    if not args.slots:
+        slots = sys_config['slot_order']
+    else:
+        slots = args.slots
+
+    reboot = not (args.no_reboot)
+    reboot_str = "hard" if reboot else "soft"
+    cmd = input(f"You are {reboot_str}-resetting slots {slots}. "
+                "Are you sure (y/n)? ")
+    if cmd.lower() not in ["y", "yes"]:
+        return
+
+    hammer(
+        slots=args.slots or None,
+        no_reboot=args.no_reboot,
+        no_dump=args.no_dump,
+        skip_setup=args.skip_setup,
+        dump_rogue=args.dump_rogue,
+    )
+
     cprint(f"Entering pysmurf slot {slots[0]}", style=TermColors.HEADER)
     enter_pysmurf(slots[0], agg=args.agg)
 

--- a/tests/test_jackhammer.py
+++ b/tests/test_jackhammer.py
@@ -1,0 +1,357 @@
+import atexit
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+# jackhammer.py reads OCS_CONFIG_DIR and parses sys_config.yml at import
+# time, so the env var and config file must exist before the import.
+_test_config_dir = tempfile.mkdtemp(prefix='jackhammer_test_')
+_test_sys_config = {
+    'crate_id': 1,
+    'shelf_manager': 'shm-smrf-sp01',
+    'slot_order': [2, 3, 4],
+    'slots': {
+        'SLOT[2]': {
+            'device_config': '$OCS_CONFIG_DIR/dev_cfg.yml',
+            'pysmurf_config': '$OCS_CONFIG_DIR/pysmurf.cfg',
+            'stream_port': 4536,
+        },
+        'SLOT[3]': {
+            'device_config': '$OCS_CONFIG_DIR/dev_cfg.yml',
+            'pysmurf_config': '$OCS_CONFIG_DIR/pysmurf.cfg',
+            'stream_port': 4537,
+        },
+        'SLOT[4]': {
+            'device_config': '$OCS_CONFIG_DIR/dev_cfg.yml',
+            'pysmurf_config': '$OCS_CONFIG_DIR/pysmurf.cfg',
+            'stream_port': 4538,
+        },
+    },
+}
+
+with open(os.path.join(_test_config_dir, 'sys_config.yml'), 'w') as f:
+    yaml.dump(_test_sys_config, f)
+
+os.environ['OCS_CONFIG_DIR'] = _test_config_dir
+atexit.register(shutil.rmtree, _test_config_dir, ignore_errors=True)
+
+try:
+    from sodetlib.hammers import jackhammer  # noqa: E402
+except ImportError as e:
+    pytest.skip(f"Missing dependency: {e}", allow_module_level=True)
+
+MODULE = 'sodetlib.hammers.jackhammer'
+
+
+def _ping_side_effect(failing_slots, exc_type=subprocess.TimeoutExpired):
+    """Emulate carrier ping results after a crate reboot.
+
+    hammer() calls ``subprocess.run(['ping_carrier', ip], timeout=...)``
+    for each slot after rebooting carriers.  This side_effect intercepts
+    those calls and raises for slots in ``failing_slots``, while letting
+    all other subprocess.run calls (e.g. ``docker stop``) succeed.
+
+    The slot number is extracted from the carrier IP, which follows the
+    convention ``10.0.<crate_id>.<slot + 100>``.
+
+    Emulated failure modes:
+      - TimeoutExpired: carrier never came back after reboot (default)
+      - Any other exc_type: unexpected error during ping (e.g. OSError
+        when the ping_carrier binary is missing)
+    """
+    def side_effect(cmd, **kwargs):
+        if isinstance(cmd, list) and cmd and cmd[0] == 'ping_carrier':
+            ip = cmd[1]
+            slot = int(ip.split('.')[-1]) - 100
+            if slot in failing_slots:
+                if exc_type is subprocess.TimeoutExpired:
+                    raise subprocess.TimeoutExpired(cmd, kwargs.get('timeout', 120))
+                raise exc_type(f"ping failed for {ip}")
+        return MagicMock(returncode=0)
+    return side_effect
+
+
+def _epics_side_effect(failing_slots, exc_type=TimeoutError):
+    """Emulate EPICS connection results after streamer dockers start.
+
+    hammer() calls ``check_epics_connection(epics_server, retry=True,
+    timeout=...)`` for each slot to wait for the pysmurf EPICS server
+    to become reachable.  This side_effect raises for slots in
+    ``failing_slots`` and returns True for the rest.
+
+    The slot number is extracted from the EPICS server name, which
+    follows the convention ``smurf_server_s<slot>``.
+
+    Emulated failure modes:
+      - TimeoutError: server never became reachable within the timeout
+        (default)
+      - Any other exc_type: unexpected error during the EPICS check
+        (e.g. a RuntimeError from the underlying caget call)
+    """
+    def side_effect(epics_server, retry=False, timeout=180):
+        slot = int(epics_server.split('_s')[-1])
+        if slot in failing_slots:
+            if exc_type is TimeoutError:
+                raise TimeoutError(
+                    f"Timed out after {timeout}s waiting for EPICS "
+                    f"connection to {epics_server}"
+                )
+            raise exc_type(f"EPICS connection error for {epics_server}")
+        return True
+    return side_effect
+
+
+def _util_run_side_effect(failing_slots=None, raising_slots=None):
+    """Emulate pysmurf setup results run inside setup_smurfs threads.
+
+    setup_smurfs() calls ``util_run('python3', args=[..., '-N', slot])``
+    in a thread per slot.  This side_effect parses the ``-N <slot>``
+    argument to determine which slot is being set up, then either
+    succeeds, returns a failing exit code, or raises.
+
+    Emulated failure modes:
+      - failing_slots: pysmurf setup ran but exited non-zero (e.g. a
+        configuration error detected by the setup script)
+      - raising_slots: the util_run call itself raised (e.g.
+        FileNotFoundError when the docker binary is missing, or a
+        subprocess error)
+    """
+    failing_slots = failing_slots or set()
+    raising_slots = raising_slots or {}
+
+    def side_effect(cmd, args=None, **kwargs):
+        args = args or []
+        if '-N' in args:
+            idx = args.index('-N')
+            if idx + 1 < len(args):
+                slot = int(args[idx + 1])
+                if slot in raising_slots:
+                    raise raising_slots[slot]
+                if slot in failing_slots:
+                    return MagicMock(returncode=1)
+        return MagicMock(returncode=0)
+    return side_effect
+
+
+@pytest.fixture
+def hammer_mocks():
+    """Patches all external dependencies of hammer() with safe defaults.
+
+    Mocks util_run rather than setup_smurfs so that the real threading
+    and error-handling code inside setup_smurfs is exercised.
+    """
+    with mock.patch.multiple(
+        MODULE,
+        dump_docker_logs=mock.DEFAULT,
+        kill_bad_dockers=mock.DEFAULT,
+        start_services=mock.DEFAULT,
+        start_sync_dockers=mock.DEFAULT,
+        controller_cmd=mock.DEFAULT,
+        run_on_shelf_manager=mock.DEFAULT,
+        setup_fans=mock.DEFAULT,
+        check_epics_connection=mock.DEFAULT,
+        util_run=mock.DEFAULT,
+        subprocess=mock.DEFAULT,
+        time=mock.DEFAULT,
+    ) as mocks:
+        mocks['subprocess'].run.return_value = MagicMock(returncode=0)
+        mocks['subprocess'].TimeoutExpired = subprocess.TimeoutExpired
+        mocks['check_epics_connection'].return_value = True
+        mocks['util_run'].return_value = MagicMock(returncode=0)
+        yield mocks
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_all_slots_succeed(hammer_mocks):
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result == {'succeeded': [2, 3, 4], 'failed': {}}
+
+
+def test_default_slots_from_config(hammer_mocks):
+    result = jackhammer.hammer(no_dump=True)
+
+    assert result == {'succeeded': [2, 3, 4], 'failed': {}}
+
+
+# ---------------------------------------------------------------------------
+# Single-stage failures
+# ---------------------------------------------------------------------------
+
+def test_single_slot_fails_at_ping(hammer_mocks):
+    hammer_mocks['subprocess'].run.side_effect = _ping_side_effect({3})
+
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result['succeeded'] == [2, 4]
+    assert 'timed out' in result['failed'][3].lower()
+
+
+def test_single_slot_fails_at_epics(hammer_mocks):
+    hammer_mocks['check_epics_connection'].side_effect = _epics_side_effect({3})
+
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result['succeeded'] == [2, 4]
+    assert 3 in result['failed']
+
+
+def test_single_slot_fails_at_setup(hammer_mocks):
+    hammer_mocks['util_run'].side_effect = _util_run_side_effect(
+        failing_slots={3}
+    )
+
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result['succeeded'] == [2, 4]
+    assert 'non-zero exit code' in result['failed'][3]
+
+
+def test_ping_generic_exception(hammer_mocks):
+    hammer_mocks['subprocess'].run.side_effect = _ping_side_effect(
+        {3}, exc_type=OSError
+    )
+
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result['succeeded'] == [2, 4]
+    assert 'Carrier ping failed' in result['failed'][3]
+
+
+def test_epics_generic_exception(hammer_mocks):
+    hammer_mocks['check_epics_connection'].side_effect = _epics_side_effect(
+        {4}, exc_type=RuntimeError
+    )
+
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result['succeeded'] == [2, 3]
+    assert 'EPICS connection failed' in result['failed'][4]
+
+
+# ---------------------------------------------------------------------------
+# Cascading / total failure
+# ---------------------------------------------------------------------------
+
+def test_all_slots_fail_at_ping_early_return(hammer_mocks):
+    hammer_mocks['subprocess'].run.side_effect = _ping_side_effect({2, 3, 4})
+
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result['succeeded'] == []
+    assert set(result['failed'].keys()) == {2, 3, 4}
+
+
+def test_multiple_failures_at_different_stages(hammer_mocks):
+    hammer_mocks['subprocess'].run.side_effect = _ping_side_effect({2})
+    hammer_mocks['check_epics_connection'].side_effect = _epics_side_effect({3})
+    hammer_mocks['util_run'].side_effect = _util_run_side_effect(
+        raising_slots={4: RuntimeError("docker not found")}
+    )
+
+    result = jackhammer.hammer(slots=[2, 3, 4], no_dump=True)
+
+    assert result['succeeded'] == []
+    assert set(result['failed'].keys()) == {2, 3, 4}
+
+
+# ---------------------------------------------------------------------------
+# Mode flags
+# ---------------------------------------------------------------------------
+
+def test_no_reboot_skips_ping_phase(hammer_mocks):
+    result = jackhammer.hammer(slots=[2, 3, 4], no_reboot=True, no_dump=True)
+
+    assert result == {'succeeded': [2, 3, 4], 'failed': {}}
+    hammer_mocks['run_on_shelf_manager'].assert_not_called()
+
+
+def test_skip_setup_mode(hammer_mocks):
+    result = jackhammer.hammer(slots=[2, 3, 4], skip_setup=True, no_dump=True)
+
+    assert result == {'succeeded': [2, 3, 4], 'failed': {}}
+    hammer_mocks['util_run'].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_invalid_slot_raises(hammer_mocks):
+    with pytest.raises(ValueError, match='not valid'):
+        jackhammer.hammer(slots=[99], no_dump=True)
+
+
+# ---------------------------------------------------------------------------
+# Direct setup_smurfs tests
+# ---------------------------------------------------------------------------
+
+@mock.patch(f'{MODULE}.util_run')
+def test_setup_smurfs_all_succeed(mock_util_run):
+    mock_util_run.return_value = MagicMock(returncode=0)
+
+    errors = jackhammer.setup_smurfs([2, 3, 4])
+
+    assert errors == {}
+    assert mock_util_run.call_count == 3
+
+
+@mock.patch(f'{MODULE}.util_run')
+def test_setup_smurfs_nonzero_exit(mock_util_run):
+    mock_util_run.side_effect = _util_run_side_effect(failing_slots={3})
+
+    errors = jackhammer.setup_smurfs([2, 3, 4])
+
+    assert 2 not in errors
+    assert 4 not in errors
+    assert 3 in errors
+    assert 'non-zero exit code' in errors[3]
+
+
+@mock.patch(f'{MODULE}.util_run')
+def test_setup_smurfs_exception_in_thread(mock_util_run):
+    mock_util_run.side_effect = _util_run_side_effect(
+        raising_slots={4: FileNotFoundError("docker binary missing")}
+    )
+
+    errors = jackhammer.setup_smurfs([2, 3, 4])
+
+    assert 2 not in errors
+    assert 3 not in errors
+    assert 4 in errors
+    assert 'Pysmurf setup raised' in errors[4]
+    assert 'docker binary missing' in errors[4]
+
+
+@mock.patch(f'{MODULE}.util_run')
+def test_setup_smurfs_thread_timeout(mock_util_run):
+    hang_event = threading.Event()
+
+    def hanging_util_run(cmd, args=None, **kwargs):
+        args = args or []
+        if '-N' in args:
+            idx = args.index('-N')
+            if idx + 1 < len(args) and int(args[idx + 1]) == 3:
+                hang_event.wait(timeout=5)
+                return MagicMock(returncode=0)
+        return MagicMock(returncode=0)
+
+    mock_util_run.side_effect = hanging_util_run
+
+    errors = jackhammer.setup_smurfs([2, 3], timeout=0.1)
+
+    hang_event.set()
+
+    assert 2 not in errors
+    assert 3 in errors
+    assert 'timed out' in errors[3].lower()


### PR DESCRIPTION
Needed for the `socs` jackhammer agent.

Allows the script to complete even if individual slots fail.